### PR TITLE
Scoot/remove group permission from all vaults

### DIFF
--- a/account-management/remove-export-all-groups-and-vault.sh
+++ b/account-management/remove-export-all-groups-and-vault.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This script removes the Export permission for ALL VAULTS that EVERY group has access to.
+# This script requires `jq` is installed on your system. See: https://stedolan.github.io/jq/ for installation instructions.
+
 vault_IDs=($(op vault list --format=json | jq --raw-output '.[] .id'))
 
 for vault in $vault_IDs 

--- a/account-management/remove-export-all-groups-and-vault.sh
+++ b/account-management/remove-export-all-groups-and-vault.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# This script removes the Export permission for ALL VAULTS that EVERY group has access to.
+# This script removes the Export permission for ALL VAULTS that EVERY group has access to. 
+# This includes the Owners and Administrators groups. 
 # This script requires `jq` is installed on your system. See: https://stedolan.github.io/jq/ for installation instructions.
 
 vault_IDs=($(op vault list --format=json | jq --raw-output '.[] .id'))

--- a/account-management/remove-export-all-groups-and-vault.sh
+++ b/account-management/remove-export-all-groups-and-vault.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+vault_IDs=($(op vault list --format=json | jq --raw-output '.[] .id'))
+
+for vault in $vault_IDs 
+do
+    echo "outer loop"
+    for group in $(op group list --vault $vault --format=json | jq --raw-output '.[] .id') 
+    do
+        echo "inner loop"
+        op vault group revoke \
+	    --permissions export_items \
+	    --group $group \
+	    --vault $vault
+    done
+done
+
+


### PR DESCRIPTION
This PR adds a new script, inspired by a customer request, to remove the Export permission for all vaults that every group has access to. 