### PR TITLE
Adding new script to generate compliance report 

### DIFF
--- a/account-management/compliance-export.sh
+++ b/account-management/compliance-export.sh
@@ -8,7 +8,7 @@
 # Replace with the tag to select all items with that tag. 
 # Note that if you specify multiple tags, they are separated by an "or", meaning
 # an item with `tag a` OR `tag b` or both `tag a` and `tag b` will be selected . 
-
+tag=""
 # This will write output to a file called reports.csv in the same directory as the script. 
 # If you prefer a different output location, change this to the path and filename of your choosing
 outputFile="report.csv"

--- a/account-management/compliance-export.sh
+++ b/account-management/compliance-export.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This script requires the use of the `jq` command line tool.
+# You will need to install it before using this script. 
+# Download `jq` from the developer: https://stedolan.github.io/jq/.
+
+
+# Replace with the tag to select all items with that tag. 
+# Note that if you specify multiple tags, they are separated by an "or", meaning
+# an item with `tag a` OR `tag b` or both `tag a` and `tag b` will be selected . 
+tag="" 
+
+# This will write output to a file called reports.csv in the same directory as the script. 
+# If you prefer a different output location, change this to the path and filename of your choosing
+outputFile="report.csv"
+
+for item in $(op item list --format=json | jq --raw-output '.[].id')
+do
+    op item get $item --tags $tag --format json | jq -r '{label: "Item Name", value: .title},{label: "Vault", value: .vault.name},{label: "Date Created", value: .created_at},{label: "Date Updated", value: .updated_at},.fields[] | select(.label != "Password") | [.label, .value] |@csv' >> $outputFile
+    echo "" >> $outputFile
+done
+
+

--- a/account-management/compliance-export.sh
+++ b/account-management/compliance-export.sh
@@ -8,16 +8,13 @@
 # Replace with the tag to select all items with that tag. 
 # Note that if you specify multiple tags, they are separated by an "or", meaning
 # an item with `tag a` OR `tag b` or both `tag a` and `tag b` will be selected . 
-tag="" 
 
 # This will write output to a file called reports.csv in the same directory as the script. 
 # If you prefer a different output location, change this to the path and filename of your choosing
 outputFile="report.csv"
 
-for item in $(op item list --format=json | jq --raw-output '.[].id')
+for item in $(op item list --tags $tag --format=json | jq --raw-output '.[].id')
 do
-    op item get $item --tags $tag --format json | jq -r '{label: "Item Name", value: .title},{label: "Vault", value: .vault.name},{label: "Date Created", value: .created_at},{label: "Date Updated", value: .updated_at},.fields[] | select(.label != "Password") | [.label, .value] |@csv' >> $outputFile
+    op item get $item --format json | jq -r '{label: "Item Name", value: .title},{label: "Vault", value: .vault.name},{label: "Date Created", value: .created_at},{label: "Date Updated", value: .updated_at},.fields[] | select(.type != "CONCEALED") | [.label, .value] |@csv' >> $outputFile
     echo "" >> $outputFile
 done
-
-


### PR DESCRIPTION
This PR adds a new script, originally written for a customer, that exports an arbitrary selection of 1Password items into a long-formatted .csv. Any concealed fields are omitted from the export. 

This script would facilitate something like a compliance employee validating the information in one or more 1Password items without giving them access to any secret values or having any unencrypted secrets on disk. 

No known issues with the script, tested on macOS only. 

Big thanks to Jack who helped immensely with the `jq` program. 

