### PR TITLE
Ensure items are not skipped if duplicate vault name exists

### DIFF
--- a/migration/lastpass-vault-item-import.py
+++ b/migration/lastpass-vault-item-import.py
@@ -12,8 +12,7 @@
 # Note: Currently TOTP secrets are not migrated. 
 # Credit to @jbsoliman
 
-
-import csv, os
+import csv, subprocess
 vault_list = []
 with open('export.csv', newline='') as csvfile:
     linereader = csv.reader(csvfile, delimiter=',', quotechar='"')
@@ -32,44 +31,47 @@ with open('export.csv', newline='') as csvfile:
             continue
         
         if not vault or vault == "":
-            os.system('''op item create --vault="Private" \\
-                --tags="%s" \\
-                --category=login \\
-                --title="%s" \\
-                --url="%s" \\
-                username="%s" \\
-                password="%s" \\
-                notes="%s"
-                ''' % (vault, title, url, username, password, notes))
+            subprocess.run(["op", "item", "create",
+                 "--vault=Private",
+                f"--tags={vault}",
+                 "--category=login",
+                f"--title={title}",
+                f"--url={url}",
+                f"username={username}",
+                f"password={password}",
+                f"notes={notes}"
+            ])
             continue
 
         if vault not in vault_list:
             vault_list.append(vault) 
             # create vault
-            os.system('op vault create "%s"'% vault)
+            subprocess.run(["op", "vault", "create", vault])
             # create item
-            os.system('''op item create --vault="%s" \\
-                --tags="%s" \\
-                --category=login \\
-                --title="%s" \\
-                --url="%s" \\
-                username="%s" \\
-                password="%s"
-                notes="%s"
-                ''' % (vault, vault, title, url, username, password, notes))
+            subprocess.run(["op", "item", "create",
+                f"--vault={vault}",
+                f"--tags={vault}",
+                 "--category=login",
+                f"--title={title}",
+                f"--url={url}",
+                f"username={username}",
+                f"password={password}",
+                f"notes={notes}"
+            ])
             continue
 
         if vault in vault_list:
             # create item
-            os.system('''op item create --vault="%s" \\
-                --tags="%s" \\
-                --category=login \\
-                --title="%s" \\
-                --url="%s" \\
-                username="%s" \\
-                password="%s"
-                notes="%s"
-                ''' % (vault, vault, title, url, username, password, notes))
+            subprocess.run(["op", "item", "create",
+                f"--vault={vault}",
+                f"--tags={vault}",
+                 "--category=login",
+                f"--title={title}",
+                f"--url={url}",
+                f"username={username}",
+                f"password={password}",
+                f"notes={notes}"
+            ])
             continue
         
         


### PR DESCRIPTION
This commit adds additional handling of vaults in three aspects:
1. The script accepts both the name "Personal" and "Private" for the personal vault.
2. The script takes the first "Personal" or "Private" vault. In my testing, the first one listed by the CLI was always the Personal/Private vault created on account creation.
3. The script tracks the UUID of vaults it creates, ensuring it uses the same vault each time.

In the current script, item migration fails if there are multiple vaults called Personal/Private or if there is an existing vault sharing the same name as the LastPass folder. The CLI throws the following error and does not prompt the user to select which vault to use:
```
[ERROR] 2023/01/01 17:51:02 More than one vault matches "vaultname". Try again and specify the vault by its ID: 
        * for the vault "vaultname": bwi5nfsg3ovzi75e7rf43hsc54
        * for the vault "vaultname": 4ttzwc2p76gpzi5gbaumgsh5ua
```