### PR TITLE
initial OTP import implementation

### DIFF
--- a/migration/lastpass-vault-item-import.py
+++ b/migration/lastpass-vault-item-import.py
@@ -49,16 +49,23 @@ with open('export.csv', newline='') as csvfile:
         title = row[5]        
         vault = row[6]
         
-        # omitting Secure Notes
+        # Omitting Secure Notes
         if url == "http://sn":
             continue
 
-        # setup for OTP 
+        # Setup for OTP 
         if otp_secret:
             otp_secret_create = "one-time-password[otp]=%s" % otp_secret
         else: 
             otp_secret_create = ""
 
+        # Account for empty fields
+        if not url:
+            url = "no URL"
+        if not title:
+            title = "Untitled Login"
+        
+        # Create item in Private/Personal vault
         if not vault or vault == "":
             if otp_secret_create:
                 subprocess.run([
@@ -87,6 +94,7 @@ with open('export.csv', newline='') as csvfile:
                 ])
             continue
 
+        # Create vault and item
         if vault not in created_vault_list:
             vault_create_command_output = None
             # create vault
@@ -102,7 +110,6 @@ with open('export.csv', newline='') as csvfile:
             new_vault_uuid = json.loads(vault_create_command_output.stdout)["id"]
             created_vault_list[vault] = new_vault_uuid
             
-            # create item
             if otp_secret_create:
                 subprocess.run([
                     "op", "item", "create",
@@ -129,7 +136,8 @@ with open('export.csv', newline='') as csvfile:
                     f"notes={notes}"
                 ])
             continue
-
+        
+        # Create item in extant vault
         if vault in created_vault_list:
             # create item
             if otp_secret_create:

--- a/migration/lastpass-vault-item-import.py
+++ b/migration/lastpass-vault-item-import.py
@@ -73,7 +73,6 @@ with open('export.csv', newline='') as csvfile:
                     f"password={password}",
                     f"notes={notes}"
                 ])
-                continue
             else:
                 subprocess.run([
                     "op", "item", "create",
@@ -117,7 +116,6 @@ with open('export.csv', newline='') as csvfile:
                     f"password={password}",
                     f"notes={notes}"
                 ])
-                continue
             else:
                 subprocess.run([
                     "op", "item", "create",
@@ -147,9 +145,8 @@ with open('export.csv', newline='') as csvfile:
                     f"password={password}",
                     f"notes={notes}"
                 ])        
-                continue
             else: 
-                       subprocess.run([
+                subprocess.run([
                     "op", "item", "create",
                     f"--vault={created_vault_list[vault]}",
                     f"--tags={vault}",

--- a/migration/lastpass-vault-item-import.py
+++ b/migration/lastpass-vault-item-import.py
@@ -44,6 +44,7 @@ with open('export.csv', newline='') as csvfile:
         url = row[0]
         username = row[1]
         password = row[2]
+        otp_secret = row[3]
         notes= row[4]
         title = row[5]        
         vault = row[6]
@@ -51,19 +52,40 @@ with open('export.csv', newline='') as csvfile:
         # omitting Secure Notes
         if url == "http://sn":
             continue
-        
+
+        # setup for OTP 
+        if otp_secret:
+            otp_secret_create = "one-time-password[otp]=%s" % otp_secret
+        else: 
+            otp_secret_create = ""
+
         if not vault or vault == "":
-            subprocess.run([
-                 "op", "item", "create",
-                f"--vault={p_vault_uuid}",
-                f"--tags={vault}",
-                 "--category=login",
-                f"--title={title}",
-                f"--url={url}",
-                f"username={username}",
-                f"password={password}",
-                f"notes={notes}"
-            ])
+            if otp_secret_create:
+                subprocess.run([
+                    "op", "item", "create",
+                    f"--vault={p_vault_uuid}",
+                    f"--tags={vault}",
+                    "--category=login",
+                    f"--title={title}",
+                    f"--url={url}",
+                    f"{otp_secret_create}",
+                    f"username={username}",
+                    f"password={password}",
+                    f"notes={notes}"
+                ])
+                continue
+            else:
+                subprocess.run([
+                    "op", "item", "create",
+                    f"--vault={p_vault_uuid}",
+                    f"--tags={vault}",
+                    "--category=login",
+                    f"--title={title}",
+                    f"--url={url}",
+                    f"username={username}",
+                    f"password={password}",
+                    f"notes={notes}"
+                ])
             continue
 
         if vault not in created_vault_list:
@@ -80,31 +102,62 @@ with open('export.csv', newline='') as csvfile:
                 continue
             new_vault_uuid = json.loads(vault_create_command_output.stdout)["id"]
             created_vault_list[vault] = new_vault_uuid
+            
             # create item
-            subprocess.run([
-                 "op", "item", "create",
-                f"--vault={created_vault_list[vault]}",
-                f"--tags={vault}",
-                 "--category=login",
-                f"--title={title}",
-                f"--url={url}",
-                f"username={username}",
-                f"password={password}",
-                f"notes={notes}"
-            ])
+            if otp_secret_create:
+                subprocess.run([
+                    "op", "item", "create",
+                    f"--vault={created_vault_list[vault]}",
+                    f"--tags={vault}",
+                    "--category=login",
+                    f"--title={title}",
+                    f"--url={url}",
+                    f"{otp_secret_create}",
+                    f"username={username}",
+                    f"password={password}",
+                    f"notes={notes}"
+                ])
+                continue
+            else:
+                subprocess.run([
+                    "op", "item", "create",
+                    f"--vault={created_vault_list[vault]}",
+                    f"--tags={vault}",
+                    "--category=login",
+                    f"--title={title}",
+                    f"--url={url}",
+                    f"username={username}",
+                    f"password={password}",
+                    f"notes={notes}"
+                ])
             continue
 
         if vault in created_vault_list:
             # create item
-            subprocess.run([
-                 "op", "item", "create",
-                f"--vault={created_vault_list[vault]}",
-                f"--tags={vault}",
-                 "--category=login",
-                f"--title={title}",
-                f"--url={url}",
-                f"username={username}",
-                f"password={password}",
-                f"notes={notes}"
-            ])        
+            if otp_secret_create:
+                subprocess.run([
+                    "op", "item", "create",
+                    f"--vault={created_vault_list[vault]}",
+                    f"--tags={vault}",
+                    "--category=login",
+                    f"--title={title}",
+                    f"--url={url}",
+                    f"{otp_secret_create}",
+                    f"username={username}",
+                    f"password={password}",
+                    f"notes={notes}"
+                ])        
+                continue
+            else: 
+                       subprocess.run([
+                    "op", "item", "create",
+                    f"--vault={created_vault_list[vault]}",
+                    f"--tags={vault}",
+                    "--category=login",
+                    f"--title={title}",
+                    f"--url={url}",
+                    f"username={username}",
+                    f"password={password}",
+                    f"notes={notes}"
+                ])   
             continue


### PR DESCRIPTION
This PR allows the script to ingest OTP secrets, if included in the LastPass export, and include those in newly-created items. 

The initial implementation is a bit verbose. I think ideally we'd have a function like `itemCreator()` that creates the correct `op item create` command for a given csv row, but with the limited scope of this script the verbosity isn't the end of the world. 