### PR TITLE
Replace slashes in vault names with underscores

### DIFF
--- a/migration/folder_migrate.py
+++ b/migration/folder_migrate.py
@@ -12,6 +12,8 @@ import csv
 import json
 import subprocess
 
+from utils import normalize_vault_name
+
 
 def migrate_folders(csv_data):
     created_vault_list = {}
@@ -27,7 +29,7 @@ def migrate_folders(csv_data):
     for row in linereader:
         vault_name = row[6] if is_csv_from_web_exporter else row[5]
         if vault_name:
-            lp_folder_list.add(vault_name)
+            lp_folder_list.add(normalize_vault_name(vault_name))
 
     for folder in lp_folder_list:
         try:

--- a/migration/utils.py
+++ b/migration/utils.py
@@ -1,0 +1,5 @@
+import re
+
+
+def normalize_vault_name(vault_name: str) -> str:
+    return re.sub(r'[^a-zA-Z0-9\s]', "_", vault_name)

--- a/migration/utils_test.py
+++ b/migration/utils_test.py
@@ -1,0 +1,6 @@
+from utils import normalize_vault_name
+
+
+def test_normalize_vault_name():
+    assert normalize_vault_name("dev\sub_dev\\nested folder") == "dev_sub_dev_nested folder"
+    assert normalize_vault_name("dev/sub_dev") == "dev_sub_dev"

--- a/migration/vault_item_import.py
+++ b/migration/vault_item_import.py
@@ -14,6 +14,8 @@ import json
 import subprocess
 import sys
 
+from utils import normalize_vault_name
+
 
 def fetch_item_template():
     # Fetch the login item template, and compare to what's expected
@@ -112,6 +114,8 @@ def migrate_items(csv_data):
             title = row[4]
             vault = row[5]
             otp_secret = None
+
+        vault = normalize_vault_name(vault)
 
         # Omitting Secure Notes
         if url == "http://sn":


### PR DESCRIPTION
This PR introduces `normalize_vault_name` that replaces all the backslashes and slashes in vault names with an underscore.

This happens when you export LastPass item located in a subdirectory. For example the item is located in `dev` -> `sub_dev` folder. Then the value in the csv file will be `dev\sub_dev`.