### PR TITLE
Open export file as UTF-8

### DIFF
--- a/migration/main.py
+++ b/migration/main.py
@@ -18,7 +18,7 @@ def main(argv):
     for opt, arg in opts:
         if opt == "--file":
             print(f'Export secrets from csv file {arg}')
-            csvfile = open(arg, newline='')
+            csvfile = open(arg, newline='', encoding="utf8")
             continue
 
         if opt in ("-f", "--folders"):


### PR DESCRIPTION
By default, Python assumes the value of `locale.getpreferredencoding()` for the encoding of files loaded as text. On Windows, this is always `cp1252`, which can result in issues with Unicode text encoding being included in the CSV. This changes the script to explicitly load the CSV as UTF-8, rather than relying on the environment. This should improve compatibility when run on Windows environments.