### PR TITLE
Enhancement: leverage --dry-run option for op item create when using --dry-run in python

### DIFF
--- a/migration/folder_migrate.py
+++ b/migration/folder_migrate.py
@@ -61,10 +61,10 @@ def migrate_folders(csv_data, options):
             stats["migrated"] += 1
         else: # if dry run
             created_vault_list[folder] = folder
-            print(f"\t\"{folder}\" => created; skipped (dry run)")
+            print(f"\t\"{folder}\" => created; (dry run)")
             stats["migrated"] += 1
 
     if not options['dry-run']:
         print(f"\nFolders migration complete!\nTotal {stats['total']} folders.\nCreated {stats['migrated']} vaults.\nSkipped {stats['skipped']}.")
     else:
-        print(f"\nFolders migration dry run complete!\nTotal {stats['total']} folders.\nCreated {stats['migrated']} vaults.\nSkipped {stats['skipped']} folders.")
+        print(f"\nFolders migration dry run complete!\nUnable to provide stats for folder-only dry runs.")

--- a/migration/vault_item_import.py
+++ b/migration/vault_item_import.py
@@ -44,9 +44,9 @@ def create_item(vault: str, template, options):
         subprocess.run([
             "op", "item", "create", "-", f"--vault={vault}"
         ], input=template, text=True, stdout=subprocess.DEVNULL)
-    else:
+    else: # If dry run
         subprocess.run([
-            "op", "item", "create", "-", f"--vault={vault}", "--dry-run"
+            "op", "item", "create", "-", "--dry-run"
         ], input=template, text=True, stdout=subprocess.DEVNULL)
 
 def migrate_items(csv_data, options):
@@ -114,7 +114,7 @@ def migrate_items(csv_data, options):
             else: 
                 normalized_vault_name = normalize_vault_name(vault)
                 created_vault_list[vault] = vault
-                print(f"\tFrom LastPass folder \"{vault}\" => created new vault \"{normalized_vault_name}\"; skipped (dry run)")
+                print(f"\tFrom LastPass folder \"{vault}\" => created new vault \"{normalized_vault_name}\" (dry run)")
                 
         template = TemplateGenerator(LPassData(
             url=url,
@@ -132,15 +132,15 @@ def migrate_items(csv_data, options):
             continue
 
         json_template = json.dumps(template)
-        if not options['dry-run']:
-            vault_to_use = created_vault_list[vault] if vault_defined else personal_vault['id']
+        vault_to_use = created_vault_list[vault] if vault_defined else personal_vault['id']
 
-        if options['dry-run']:
-            print(f"\t\"{title}\" => migrated; skipped (dry run)")
-            continue
-
-        create_item(vault_to_use, json_template)
+        create_item(vault_to_use, json_template, options)
         stats["migrated"] += 1
-        print(f"\t\"{title}\" => migrated")
-
-    print(f"\nMigration complete!\nTotal {stats['total']} credentials.\nMigrated {stats['migrated']} credentials.\nCreated {stats['vaults']} vaults.\nSkipped {stats['skipped']} credentials.")
+        if options['dry-run']:
+            print(f"\t\"{title}\" => migrated (dry-run)")
+        else:
+            print(f"\t\"{title}\" => migrated")
+    if options['dry-run']:
+        print(f"\nMigration complete!\nTotal {stats['total']} credentials.\nMigrated {stats['migrated']} credentials.\nCreated {stats['vaults']} vaults (Vault stats unavailble during dry-run).\nSkipped {stats['skipped']} credentials.")
+    else: 
+        print(f"\nMigration complete!\nTotal {stats['total']} credentials.\nMigrated {stats['migrated']} credentials.\nCreated {stats['vaults']} vaults.\nSkipped {stats['skipped']} credentials.")

--- a/migration/vault_item_import.py
+++ b/migration/vault_item_import.py
@@ -38,12 +38,16 @@ def fetch_personal_vault():
     return personal_vault
 
 
-def create_item(vault: str, template):
+def create_item(vault: str, template, options):
     # Create item
-    subprocess.run([
-        "op", "item", "create", "-", f"--vault={vault}"
-    ], input=template, text=True, stdout=subprocess.DEVNULL)
-
+    if not options['dry-run']:
+        subprocess.run([
+            "op", "item", "create", "-", f"--vault={vault}"
+        ], input=template, text=True, stdout=subprocess.DEVNULL)
+    else:
+        subprocess.run([
+            "op", "item", "create", "-", f"--vault={vault}", "--dry-run"
+        ], input=template, text=True, stdout=subprocess.DEVNULL)
 
 def migrate_items(csv_data, options):
     created_vault_list = {}


### PR DESCRIPTION
This PR enhances the features introduced in #32 by using the `--dry-run` option for `op item create` when a person runs this script with `--dry-run` selected. 

This means the dry-run should better represent the item creation behaviour when they run the script not on a dry-run. 

- [x] Modify create_item() to receive `options` and set up conditional to use `op item create...--dry-run` 
- [x] refactor the `stats` var to count results of dry run for items. 
- [x] test

