### PR TITLE
Add script to change HTTP to HTTPs for URLs for Login items

### DIFF
--- a/item-management/replace-http-with-https.sh
+++ b/item-management/replace-http-with-https.sh
@@ -2,7 +2,8 @@
 #########################################################
 # REPLACE HTTP WITH HTTPS 
 #########################################################
-# This script replaces or adds the value of the website field for all items in a specified vault
+# This script will replace "http" with "https" for the 
+# website field of all Login items in the specified vault 
 
 #Provide a vault UUID or vault name
 vaultUUID=""

--- a/item-management/replace-http-with-https.sh
+++ b/item-management/replace-http-with-https.sh
@@ -8,7 +8,7 @@
 vaultUUID=""
 
 # add new url to each item
-for item in $(op item list --vault $vaultUUID --format=json | jq --raw-output '.[].id')
+for item in $(op item list --vault $vaultUUID --categories Login --format json | jq --raw-output '.[].id')
 do
 	oldURL=$(op item get $item --format=json | jq --raw-output '.urls[].href')
 	newURL=$(echo $oldURL | sed 's/^http:\/\//https:\/\//g')

--- a/item-management/replace-http-with-https.sh
+++ b/item-management/replace-http-with-https.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#########################################################
+# REPLACE HTTP WITH HTTPS 
+#########################################################
+# This script replaces or adds the value of the website field for all items in a specified vault
+
+#Provide a vault UUID or vault name
+vaultUUID=""
+
+# add new url to each item
+for item in $(op item list --vault $vaultUUID --format=json | jq --raw-output '.[].id')
+do
+	oldURL=$(op item get $item --format=json | jq --raw-output '.urls[].href')
+	newURL=$(echo $oldURL | sed 's/^http:\/\//https:\/\//g')
+	op item edit $item website=$newURL
+done


### PR DESCRIPTION
This PR adds a script that loops through all items in a vault and replaces `http` with `https` for URLs in the Website field of items. 

It's simple, and a functional proof of concept that would be great out of the box for individual users. 

This would work well for people who were looking to address Watchtower notifications for non-HTTPS items in bulk. 