### PR TITLE
add vault flag to op commands for SA

### DIFF
--- a/item-management/replace-http-with-https.sh
+++ b/item-management/replace-http-with-https.sh
@@ -11,7 +11,7 @@ vaultUUID=""
 # add new url to each item
 for item in $(op item list --vault $vaultUUID --categories Login --format json | jq --raw-output '.[].id')
 do
-	oldURL=$(op item get $item --format=json | jq --raw-output '.urls[].href')
+	oldURL=$(op item get $item --vault $vaultUUID --format=json | jq --raw-output '.urls[].href')
 	newURL=$(echo $oldURL | sed 's/^http:\/\//https:\/\//g')
-	op item edit $item website=$newURL
+	op item edit $item --vault $vaultUUID website=$newURL
 done


### PR DESCRIPTION
resolves #38 

adds `--vault` flags to relevant `op` commands to accommodate Service Accounts that have access to multiple vaults. 