### PR TITLE
Create script to recreate folder metadata.

### DIFF
--- a/migration/cleanup-scripts/README.md
+++ b/migration/cleanup-scripts/README.md
@@ -7,6 +7,7 @@ This is a collection of scripts that can help you clean up your 1Password accoun
 * [`vault_dedupe_helper.py`](#identify-duplicate-vaults-for-removal-with-vault_dedupe_helperpy) generates a report for all shared vaults in your account that can help you identify which duplicates to delete, and which to retain. 
 * [`add_vault_prefix.py`](#further-investigate-or-delete-potential-duplicate-vaults-with-add_vault_prefixpy) can take a list of vault UUIDs and prefix each vault name with `!` to make them easy to identify in 1Password for further assessment. Alternatively using the `--delete` option will delete each vault provided in the list. 
 * [`remove_imported_prefix.py`](#remove-imported-prefix-from-imported-vaults-with-remove_imported_prefixpy) will remove the "Imported " prefix from the name of all vaults in your 1Password account. Handy to clean things up once you have finalized your migration. 
+* [`recreate_metadata_entry.py`](#recreate-metadata-entry) will reconstruct the metadata entries in the metadata vault to point to the oldest imported vaults
 
 > **note**  
 > Learn more about migrating your data from LastPass to 1Password [here](https://support.1password.com/import-lastpass/).  
@@ -87,3 +88,21 @@ It assumes you have signed in to your 1Password account as a member of the Owner
 
 > **warning**  
 > Run this script only after you have migrated all data from LastPass and have migrated permissions for all groups and users. Removing the Imported prefix or changing the name of imported vaults in any way before you have finalized your migration may result in duplicate vaults or failure to migrate permissions. 
+
+
+## Recreate the metadata vault metadata entries after a duplication occurred with [`recreate_metadata_entry.py`](./recreate_metadata_entry.py)
+
+This script will recreate the metadata folder entries. An 'import folder permissions only' will correctly find the old vaults, rather than create empty duplicate vaults again.
+
+### Usage
+
+Run `python3 vault_dedupe_helper.py` to regenerate the dedup CSV.
+
+Then run `python3 recreate_metadata_entry.py` which will create a `LastPass Metadata Recreated` item in the LastPass metadata vault.
+
+The script requires no arguments and has no flags or options. 
+
+It assumes you have signed in to your 1Password account as a member of the Owners group using `op signin` or `eval $(op signin)`. 
+
+> **warning**  
+> After running this script archive all other `LastPass Metadata <date>` items except for `LastPass Metadata Recreated`. This will ensure that duplication will not occur again when importing permissions.

--- a/migration/cleanup-scripts/README.md
+++ b/migration/cleanup-scripts/README.md
@@ -92,7 +92,7 @@ It assumes you have signed in to your 1Password account as a member of the Owner
 
 ## Recreate the metadata vault metadata entries after a duplication occurred with [`recreate_metadata_entry.py`](./recreate_metadata_entry.py)
 
-This script will recreate the metadata folder entries. An 'import folder permissions only' will correctly find the old vaults, rather than create empty duplicate vaults again.
+This script will recreate the metadata folder entries. Once recreated, using the LastPass importer in the 1Password desktop application with 'import folder permissions only' selected will correctly find the old vaults, rather than create empty duplicate vaults again.
 
 ### Usage
 

--- a/migration/cleanup-scripts/recreate_metadata_entry.py
+++ b/migration/cleanup-scripts/recreate_metadata_entry.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+import csv
+import json
+from collections import defaultdict
+from datetime import datetime
+
+scriptPath = os.path.dirname(__file__)
+outputPath = scriptPath  # Optionally choose an alternative output path here.
+
+class Vault:
+    def __init__(self, csvRow):
+        self.name = csvRow[0]
+        self.uuid = csvRow[1]
+        self.itemCount = csvRow[2]
+        self.created = csvRow[3]
+        self.updated = csvRow[4]
+        self.userCount = csvRow[5]
+
+
+def findMetadataVaultUuid(vaults: dict):
+    for k, v in vaults.items():
+        if v == "❗️ LastPass Imported Shared Folders Metadata":
+            return k
+    return None
+
+
+def getVaultItems(vaultID):
+    try:
+        return subprocess.run(f"op item list --vault {vaultID} --format=json", shell=True, check=True, capture_output=True).stdout
+    except (Exception) as err:
+        print(f"Encountered an error getting items for vault {vaultID}: ", err)
+        return
+
+
+def getItemDetails(vaultUuid, itemUuid):
+    try:
+        return subprocess.run(f"op item get {itemUuid} --vault {vaultUuid} --format=json", shell=True, check=True, capture_output=True).stdout
+    except (Exception) as err:
+        print(f"Encountered an error getting item details for item {itemUuid} vault {vaultUuid}: ", err)
+        return
+
+
+def createItem(vaultUuid, itemJson: str):
+    from subprocess import Popen, PIPE, STDOUT
+    try:
+        p = Popen(["op", "item", "create", "--vault", vaultUuid], stdout=PIPE, stdin=PIPE, stderr=PIPE)
+        return p.communicate(input=itemJson.encode("utf-8"))[0]
+    except (Exception) as err:
+        print(f"Encountered an error creating an item in vault {vaultUuid}: ", err)
+        return
+
+
+def readDate(date):
+    return datetime.strptime(date, '%Y-%m-%d %H:%M:%S').timestamp()
+
+
+def findOriginalVault(vaults):
+    minimum = (0, readDate(vaults[0].created))
+    for i, vault in enumerate(vaults):
+        date = readDate(vault.created)
+        if date < minimum[1]:
+            minimum = (i, date)
+    return vaults[minimum[0]]
+
+
+def removeImportedPrefix(text):
+    prefix = "Imported "
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
+
+def main():
+    # all vaults ordered by UUID
+    vaults = {}
+    # vaults ordered by name
+    duplicateVaults = defaultdict(list)
+    with open(f"{outputPath}/vaultreport.csv", "r", newline="") as vaultFile:
+        csvReader = csv.reader(vaultFile)
+        for row in csvReader:
+            # we remove the 'Imported ' prefix from all vaults before processing them in case any
+            # of them got renamed
+            row[0] = removeImportedPrefix(row[0])
+            duplicateVaults[row[0]].append(Vault(row))
+            vaults[row[1]] = row[0]
+
+    # find the metadata vault
+    metadataVaultUuid = findMetadataVaultUuid(vaults)
+    # get its items
+    metadataItems = json.loads(getVaultItems(metadataVaultUuid))
+    itemDetails = [json.loads(getItemDetails(metadataVaultUuid, item["id"])) for item in metadataItems]
+    updatedFields = []
+    for item in itemDetails:
+        # find the LastPass metadata fields and process them
+        for field in item.get("fields", []):
+            ids = field["id"].split(".LPID.")
+            if len(ids) != 2:
+                continue
+            vaultUuid = ids[0]
+            lpId = ids[1]
+            name = vaults.get(vaultUuid, "")
+            # We found a metadata entry that points to a vault that exists.
+            # We will find the vault with the same name, but that got created first
+            # and we will save the new metadata entry
+            if len(name) > 0:
+                dupVaults = duplicateVaults[name]
+                origVault = findOriginalVault(dupVaults)
+                updatedFields.append({
+                    "id": f"{origVault.uuid}.LPID.{lpId}",
+                    "type": field["type"],
+                    "value": field["value"],
+                })
+
+    # create a new metadata record with the updated entries
+    newItemFields = [{
+        "id": "notesPlain",
+        "type": "STRING",
+        "purpose": "NOTES",
+        "label": "notesPlain",
+        "value": ""
+    }]
+    newItemFields.extend(updatedFields)
+    newItem =  {
+        "title": "LastPass Metadata Recreated",
+        "category": "SECURE_NOTE",
+        "fields": newItemFields
+    }
+    createItem(metadataVaultUuid, json.dumps(newItem))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This should help detect metadata entries that point to the newly duplicated vaults and edit them to point to the old vaults.