### PR TITLE
This PR adds warnings about breaking changes in CLI v >= 2.22

### DIFF
--- a/migration/cleanup-scripts/README.md
+++ b/migration/cleanup-scripts/README.md
@@ -2,6 +2,9 @@
 
 This is a collection of scripts that can help you clean up your 1Password account after performing a migration from LastPass. 
 
+> **Warning**  
+> Currently, you must use version 2.21 or older of the 1Password CLI when running these scripts. Version 2.22 and newer introduced changes that prevent these scripts from performing as-expected. Download version 2.21 the 1Password website [here](https://app-updates.agilebits.com/product_history/CLI2#v2210002).
+
 ## Contents
 
 * [`vault_dedupe_helper.py`](#identify-duplicate-vaults-for-removal-with-vault_dedupe_helperpy) generates a report for all shared vaults in your account that can help you identify which duplicates to delete, and which to retain. 

--- a/migration/cleanup-scripts/README.md
+++ b/migration/cleanup-scripts/README.md
@@ -2,7 +2,7 @@
 
 This is a collection of scripts that can help you clean up your 1Password account after performing a migration from LastPass. 
 
-> **Warning**  
+> ⚠️ **Warning**  
 > Currently, you must use version 2.21 or older of the 1Password CLI when running these scripts. Version 2.22 and newer introduced changes that prevent these scripts from performing as-expected. Download version 2.21 the 1Password website [here](https://app-updates.agilebits.com/product_history/CLI2#v2210002).
 
 ## Contents

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -2,7 +2,7 @@
 
 This directory provides a series of scripts demonstrating how to use the CLI to generate summary reports of vault access, contents, and permissions.
 
-> **Warning**  
+> ⚠️ **Warning**  
 > Currently, you must use version 2.21 or older of the 1Password CLI when running these scripts. Version 2.22 and newer introduced changes that prevent these scripts from performing as-expected. Download version 2.21 the 1Password website [here](https://app-updates.agilebits.com/product_history/CLI2#v2210002).
 
 ## [`user-and-item-list.py`](./user-and-item-list.py)

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -2,6 +2,9 @@
 
 This directory provides a series of scripts demonstrating how to use the CLI to generate summary reports of vault access, contents, and permissions.
 
+> **Warning**  
+> Currently, you must use version 2.21 or older of the 1Password CLI when running these scripts. Version 2.22 and newer introduced changes that prevent these scripts from performing as-expected. Download version 2.21 the 1Password website [here](https://app-updates.agilebits.com/product_history/CLI2#v2210002).
+
 ## [`user-and-item-list.py`](./user-and-item-list.py)
 
 - Creates a csv file of each user and item that has access to a list of vaults.


### PR DESCRIPTION
CLI version 2.22 introduced changes to the information returned by `op vault list --group Owners`. These changes prevent the scripts that depend on that command from returning an exhaustive list of non-Private vaults in a 1Password Business account. 

Until equivalent functionality is returned to the CLI, anyone depending on certain scripts in this repository will need to use CLI v <= 2.21. 

At a later date, I will introduce version checks to affected scripts to provide script users with feedback. 