### PR TITLE
Add script to add or remove permissions for all shared vaults for all users and groups 

### DIFF
--- a/account-management/README.md
+++ b/account-management/README.md
@@ -6,29 +6,45 @@ These examples are intended to demonstrate how the 1Password command line tool c
 
 ## Script Descriptions
 
-### [vault-details.sh](vault-details.sh)
+### [vault-details.sh](./vault-details.sh)
 
 When run by a member of the Owners group, this script provides the vault name, the number of items in the vault, the last time the vault contents were updated, and list which users and groups have access to that vault along with their permissions.
 
 When run by a non-Owner, it will provide these details for all vaults the user running the script has access to.
 
-### [remove-export-all-groups-and-vaults.sh](remove-export-all-groups-and-vault.sh)
+### [remove-export-all-groups-and-vaults.sh](./remove-export-all-groups-and-vault.sh)
 
 When run by a member of the Owners group, this script will remove the `export items` permission for every vault that every group has access to without exception.
 
 When run by a non-Owner, this script will remove the `export` permission on vaults that the person running the script also has the `manage vault` permissions for.
 
-### [vault-permission-change.sh](vault-permission-change.sh)
+### [vault-permission-change.sh](./vault-permission-change.sh)
 
 This script, when run by an a user with the `manage vault` (manage access) permission, will remove or add the specified vault permission(s) for the specified group(s) from all vaults (excluding Private vaults). This could be useful if you are looking to systematically remove the Administrators `manage vault` (manage access) permission from all created shared vaults, this leaving this permission to the default owners group. 
 
-### [bulk-group-prefix-update.sh](bulk-group-prefix-update.sh)
+### [`vault-permission-change.py`](./vault-permission-change.py)
+
+Similar to [`vault-permission-change.sh`](#vault-permission-changesh) above, but with several additional options. It is also written in Python for greater cross-compatibility. 
+
+When run by a member of the Owners group, for each vault the person running the script has at "Manage Vault" permissions for, the specified permission(s) will be removed from all people or groups assigned to the vault. Permissions for Owners and Administrators groups are not affected. Using the `--grant` or `-g` option will grant the specified permissions instead of revoking them.  
+
+If a permission [has dependencies on other permissions](https://developer.1password.com/docs/cli/vault-permissions/), the script will automatically grant or revoke the dependent permissions. 
+
+The script accepts the following options:
+
+`--permission -p` Required. Use one or more times to specify a permission to be added or removed. This option can be specified an arbitrary number of times. A list of permissions is listed in the script's Help, or [learn more about vault permissions](https://developer.1password.com/docs/cli/vault-permissions/)
+`--grant -g` Optional. Grants, rather than revokes, the specified permissions. 
+`--as-admin` Optional. Use this flag if the person running the script is a member of the Administrators group, not the Owners group.
+
+
+
+### [bulk-group-prefix-update.sh](./bulk-group-prefix-update.sh)
 
 This script, when run by an Owner or Administrator, will change the prefix of all group names according to your specifications. This is particularly helpful if you are needing to change an existing naming scheme.
 If you want to add prefixes where one doesn't already exist, then you can modify the `sed` substitution to: `sed 's/^/PREFIX/g'` to add a prefix to all groups.
 This does not change the name of any built in groups (e.g., "Administrators", "Owners", "Team Members").
 
-### [compliance-export.sh](compliance-export.sh)
+### [compliance-export.sh](./compliance-export.sh)
 
 This script, when run by an adminstrator, will output all items within the specified scope (e.g., with a specific tag) as a long-formatted CSV. The export excludes any concealed fields such as password fields.
 This script may be helpful if you need to have someone verify the accuracy of the details of a 1Password item without revealing any secret values stored in that item.

--- a/account-management/README.md
+++ b/account-management/README.md
@@ -6,19 +6,19 @@ These examples are intended to demonstrate how the 1Password command line tool c
 
 ## Script Descriptions
 
-### [vault-details.sh](./vault-details.sh)
+### [`vault-details.sh`](./vault-details.sh)
 
 When run by a member of the Owners group, this script provides the vault name, the number of items in the vault, the last time the vault contents were updated, and list which users and groups have access to that vault along with their permissions.
 
 When run by a non-Owner, it will provide these details for all vaults the user running the script has access to.
 
-### [remove-export-all-groups-and-vaults.sh](./remove-export-all-groups-and-vault.sh)
+### [`remove-export-all-groups-and-vaults.sh`](./remove-export-all-groups-and-vault.sh)
 
 When run by a member of the Owners group, this script will remove the `export items` permission for every vault that every group has access to without exception.
 
 When run by a non-Owner, this script will remove the `export` permission on vaults that the person running the script also has the `manage vault` permissions for.
 
-### [vault-permission-change.sh](./vault-permission-change.sh)
+### [`vault-permission-change.sh`](./vault-permission-change.sh)
 
 This script, when run by an a user with the `manage vault` (manage access) permission, will remove or add the specified vault permission(s) for the specified group(s) from all vaults (excluding Private vaults). This could be useful if you are looking to systematically remove the Administrators `manage vault` (manage access) permission from all created shared vaults, this leaving this permission to the default owners group. 
 
@@ -38,13 +38,13 @@ The script accepts the following options:
 
 
 
-### [bulk-group-prefix-update.sh](./bulk-group-prefix-update.sh)
+### [`bulk-group-prefix-update.sh`](./bulk-group-prefix-update.sh)
 
 This script, when run by an Owner or Administrator, will change the prefix of all group names according to your specifications. This is particularly helpful if you are needing to change an existing naming scheme.
 If you want to add prefixes where one doesn't already exist, then you can modify the `sed` substitution to: `sed 's/^/PREFIX/g'` to add a prefix to all groups.
 This does not change the name of any built in groups (e.g., "Administrators", "Owners", "Team Members").
 
-### [compliance-export.sh](./compliance-export.sh)
+### [`compliance-export.sh`](./compliance-export.sh)
 
 This script, when run by an adminstrator, will output all items within the specified scope (e.g., with a specific tag) as a long-formatted CSV. The export excludes any concealed fields such as password fields.
 This script may be helpful if you need to have someone verify the accuracy of the details of a 1Password item without revealing any secret values stored in that item.

--- a/account-management/vault-permission-change.py
+++ b/account-management/vault-permission-change.py
@@ -7,12 +7,10 @@ import argparse
 
 scriptPath = os.path.dirname(__file__)
 
-
 parser = argparse.ArgumentParser(
     "Bulk-revoke permissions.",
     "Revoke one or more specified permissions from all users and groups for all vaults the person running the script can access. ",
 )
-
 parser.add_argument(
     "--grant",
     "-g",

--- a/account-management/vault-permission-change.py
+++ b/account-management/vault-permission-change.py
@@ -1,0 +1,126 @@
+import os
+import subprocess
+import json
+import sys
+import argparse
+
+
+scriptPath = os.path.dirname(__file__)
+
+
+parser = argparse.ArgumentParser(
+    "Bulk-revoke permissions.",
+    "Revoke one or more specified permissions from all users and groups for all vaults the person running the script can access. ",
+)
+parser.add_argument(
+    "--as-admin",
+    action="store_true",
+    dest="isAdmin",
+    help="Set this flag if you are running this script as a member of the Administrators group.",
+)
+parser.add_argument(
+    "--permissions",
+    "-p",
+    action="store",
+    dest="permissions",
+    help=f"Provide a comma-seprated list of permissions to revoke using the following permission names: view_items, create_items, edit_items, archive_items, delete_items, view_and_copy_passwords, view_item_history, import_items, export_items, copy_and_share_items, print_items, manage_vault",
+)
+args = parser.parse_args()
+
+if args.isAdmin:
+    userGroup = "Administrators"
+else:
+    userGroup = "Owners"
+
+permissions = args.permissions
+
+
+# get a list of vaults the logged-in user has access to
+def getAllOwnerVaults():
+    return subprocess.run(
+        ["op", "vault", "list", f"--group={userGroup}", "--format=json"],
+        check=True,
+        capture_output=True,
+    ).stdout
+
+
+# Gets a list of all vaults the Owner has Manage Vault permissions on
+def getVaultUserList(vaultID):
+    return subprocess.run(
+        ["op", "vault", "user", "list", vaultID, "--format=json"],
+        check=True,
+        capture_output=True,
+    ).stdout
+
+
+# get all groups that have access to the specified vault, excluding Owners and Administrators group
+def getVaultGroupList(vaultUUID):
+    allgroups = subprocess.run(
+        ["op", "vault", "group", "list", vaultUUID, "--format=json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return allgroups
+
+
+# revokes the specified vault permissions from the grou
+def revokeGroupPermissions(vaultUUID, groupUUID):
+    subprocess.run(
+        [
+            "op",
+            "vault",
+            "group",
+            "revoke",
+            f"--vault={vaultUUID}",
+            f"--group={groupUUID}",
+            f"--permissions={permissions}",
+            "--no-input",
+        ]
+    )
+
+
+# revokes the specified vault permissions from the grou
+def revokeUserPermissions(vaultUUID, userUUID):
+    subprocess.run(
+        [
+            "op",
+            "vault",
+            "user",
+            "revoke",
+            f"--vault={vaultUUID}",
+            f"--user={userUUID}",
+            f"--permissions={permissions}",
+            "--no-input",
+        ]
+    )
+
+
+def main():
+    if permissions is None:
+        sys.exit(
+            "Please provide a list of permissions with --permissions=PERMISSIONS and run the script again"
+        )
+
+    accountVaults = json.loads(getAllOwnerVaults())
+
+    for vault in accountVaults:
+        print(f"HI! {vault['id']}")
+        vaultGroups = json.loads(getVaultGroupList(vault["id"]))
+        vaultUsers = json.loads(getVaultUserList(vault["id"]))
+        print("VAULT GROUPS: ", vaultGroups)
+
+        for group in vaultGroups:
+            if group["name"] == "Administrators":
+                print("ADMINISTRATOR")
+            elif group["name"] == "Owners":
+                print("OWNER")
+            else:
+                print("NEITHER OWNER NOR ADMIN: ", group["name"])
+                revokeGroupPermissions(vault["id"], group["id"])
+
+        for user in vaultUsers:
+            revokeUserPermissions(vault["id"], user["id"])
+
+
+main()


### PR DESCRIPTION
This PR introduces a script, which is an updated version of an existing script, allowing a member of the Owners or Administrators group to update users' and groups' vault permissions for all vaults the Owner or Administrator has Manage Vault access for (when using CLI v2.21 or older). 

This also includes an updated README describe the new script and it's usage. 

Two things left to do before final review:
- [ ] Handle permissions dependencies (currently the permission change is ignored if there are dependencies)
- [ ] Add CLI version dependency callout to README. 