### PR TITLE
add script to identify duplicate vaults and move items to tracked vault

### DIFF
--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -11,6 +11,15 @@ scriptPath = os.path.dirname(__file__)
 outputPath = scriptPath  # Optionally choose an alternative output path here.
 
 
+class Vault:
+    def __init__(self, name, uuid, itemCount, created, updated):
+        self.name = name
+        self.uuid = uuid
+        self.itemCount = itemCount
+        self.created = created
+        self.updated = updated
+
+
 # Get a list of vaults the logged-in user has access to
 def getVaults():
     try:
@@ -41,6 +50,13 @@ def getVaultDetails(vaultID):
 
 def main():
     vaults = json.loads(getVaults())
+
+    # Collect all vaults
+    # Identify identically named vaults
+    # For a set of duplicates, sort by number of items
+    # Move items from vault with most items to vault with zero
+    # prefix duplicates with `dup-` and if more than one, add numeric suffix
+    # remove all permissions from non-canonical vaults
 
 
 main()

--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -57,6 +57,33 @@ def getVaults():
         return
 
 
+# From a list of vaults within a group of identically-named vaults
+def identifyTrackedVault(vaultGroupName, vaults):
+    # Return early if vaultgroup contains a single vault.
+    if len(vaults) == 1:
+        print(f"Vault with name {vaultGroupName} is unique. Skipping de-duplication.")
+        return
+
+    print("Vault group name being processed: ", vaultGroupName)
+
+    # Sort by item count to facilitate identifying tracked and data vaults
+    vaults.sort(key=lambda vault: vault.itemCount)
+
+    # Identity vault with greatest number of items, assumption being it has canonical data
+    dataVault = vaults[-1]
+
+    # Identify vault with zero items, assumption is that is tracked by metadata vault
+    trackedVault = vaults[0]
+
+    # triplicates or greater that are not data or tracked
+    otherVaults = vaults[1:-1]
+    print("dataVault: ", dataVault.name, "items: ", dataVault.itemCount)
+    print("trackedVault: ", trackedVault.name, "items: ", trackedVault.itemCount)
+    for v in otherVaults:
+        print("Other Vaults: ", v.name, "item count: ", v.itemCount)
+    return (dataVault, trackedVault, otherVaults)
+
+
 def main():
     vaults = []
     vaultGroups = {}
@@ -86,9 +113,7 @@ def main():
         vaultGroups[vault.name].append(vault)
 
     for groupName, vaults in vaultGroups.items():
-        print(groupName)
-        for vault in vaults:
-            print(f"\t Name: ", vault.name, "Items: ", vault.itemCount)
+        identifyTrackedVault(groupName, vaults)
 
     # Collect all vaults
     # Identify identically named vaults

--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -1,11 +1,7 @@
 #!/usr/bin/python3
-
+import json
 import os
 import subprocess
-import csv
-import json
-from collections import defaultdict
-from datetime import datetime
 
 scriptPath = os.path.dirname(__file__)
 outputPath = scriptPath  # Optionally choose an alternative output path here.
@@ -222,12 +218,13 @@ def main():
             )
         )
 
-    # Ensure vaults are alpha sorted
+    # Ensure vaults are alpha sorted to make grouping duplicates easier and more reliable
     vaults.sort(key=lambda vault: vault.name)
 
-    # Create a dict containing groups of identically named vaults.
+    # Create a dict containing groups of identically-named vaults.
     # Dict keys are a vault name representing all vaults with that name.
-    # The value for each key is a list of Vault class instances
+    # The value for each key is a list of Vault class instances with that name,
+    # forming a vault group.
     for vault in vaults:
         if vault.name not in vaultGroups:
             vaultGroups[vault.name] = []

--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -36,7 +36,7 @@ def getVaults():
                 print("Skipping Private vault")
                 continue
             if "Imported Shared Folders Metadata" in vault["name"]:
-                print("Skipping metadata vault")
+                print("Skipping LastPass Import Metadata vault")
                 continue
             processResults = subprocess.run(
                 ["op", "vault", "get", vault["id"], "--format=json"],
@@ -45,7 +45,7 @@ def getVaults():
             )
             if processResults.stderr:
                 print(
-                    f"encountered an error geting details of a vault: {processResults.stderr}"
+                    f"encountered an error geting details of a vault: {str(processResults.stderr)}"
                 )
                 continue
             vaults.append(json.loads(processResults.stdout))
@@ -115,15 +115,15 @@ def moveItemsToTrackedVault(trackedVault, dataVault):
 
 # Rename all untracked vaults
 def renameUntrackedVaults(untrackedVaults):
+    suffix = 1
     for vault in untrackedVaults:
-        suffix = 1
         newName = f"dup-{vault.name}-{suffix}"
         renameCmd = subprocess.run(
             ["op", "vault", "edit", vault.uuid, f"--name={newName}"],
             check=True,
             capture_output=True,
         )
-        print(renameCmd)
+        print(renameCmd.stdout)
         suffix += 1
 
 

--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -33,7 +33,7 @@ def getVaults():
         )
         for vault in json.loads(getVaultsCommand.stdout):
             if "Private" in vault["name"]:
-                print("Skipping private vault")
+                print("Skipping Private vault")
                 continue
             if "Imported Shared Folders Metadata" in vault["name"]:
                 print("Skipping metadata vault")
@@ -59,36 +59,138 @@ def getVaults():
 
 # From a list of vaults within a group of identically-named vaults
 def identifyTrackedVault(vaultGroupName, vaults):
-    # Return early if vaultgroup contains a single vault.
-    if len(vaults) == 1:
-        print(f"Vault with name {vaultGroupName} is unique. Skipping de-duplication.")
-        return
-
     print("Vault group name being processed: ", vaultGroupName)
 
     # Sort by item count to facilitate identifying tracked and data vaults
     vaults.sort(key=lambda vault: vault.itemCount)
 
     # Identity vault with greatest number of items, assumption being it has canonical data
-    dataVault = vaults[-1]
+    dataVault = vaults[0]
 
     # Identify vault with zero items, assumption is that is tracked by metadata vault
-    trackedVault = vaults[0]
+    trackedVault = vaults[-1]
 
     # triplicates or greater that are not data or tracked
     otherVaults = vaults[1:-1]
-    print("dataVault: ", dataVault.name, "items: ", dataVault.itemCount)
-    print("trackedVault: ", trackedVault.name, "items: ", trackedVault.itemCount)
-    for v in otherVaults:
-        print("Other Vaults: ", v.name, "item count: ", v.itemCount)
-    return (dataVault, trackedVault, otherVaults)
+
+    return dataVault, trackedVault, otherVaults
+
+
+def getVaultItems(vaultID):
+    try:
+        return subprocess.run(
+            ["op", "item", "list", f"--vault={vaultID}", "--format=json"],
+            check=True,
+            capture_output=True,
+        ).stdout
+    except Exception as err:
+        print(f"Encountered an error getting items for vault {vaultID}: ", err)
+        return
+
+
+# Move items from data vault to tracked vault.
+def moveItemsToTrackedVault(trackedVault, dataVault):
+    items = json.loads(getVaultItems(dataVault.uuid))
+    for item in items:
+        try:
+            moveCmd = subprocess.run(
+                [
+                    "op",
+                    "item",
+                    "move",
+                    item["id"],
+                    f"--current-vault={dataVault.uuid}",
+                    f"--destination-vault={trackedVault.uuid}",
+                ],
+                check=True,
+                capture_output=True,
+            )
+            if moveCmd.stderr:
+                print(moveCmd.err)
+        except Exception as err:
+            print(
+                f"Unable to move item with name '{item['title']}' and ID of '{item['id']}' with error: {err}"
+            )
+
+
+# Rename all untracked vaults
+def renameUntrackedVaults(untrackedVaults):
+    for vault in untrackedVaults:
+        suffix = 1
+        newName = f"dup-{vault.name}-{suffix}"
+        renameCmd = subprocess.run(
+            ["op", "vault", "edit", vault.uuid, f"--name={newName}"],
+            check=True,
+            capture_output=True,
+        )
+        print(renameCmd)
+        suffix += 1
+
+
+# revoke all access and permissions from untracked vaults
+def revokeUntrackedVaultPermissions(untrackedVaults):
+    for vault in untrackedVaults:
+        print(f"Modifying permissions for vault '{vault.name}'.")
+        allgroups = json.loads(
+            subprocess.run(
+                ["op", "vault", "group", "list", vault.uuid, "--format=json"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+        allUsers = json.loads(
+            subprocess.run(
+                ["op", "vault", "user", "list", vault.uuid, "--format=json"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+
+        for group in allgroups:
+            print(
+                f"\t Revoking group {group['name']} permissions for vault '{vault.name}'"
+            )
+            groupRevokeCmd = subprocess.run(
+                [
+                    "op",
+                    "vault",
+                    "group",
+                    "revoke",
+                    f"--vault={vault.uuid}",
+                    f"--group={group['id']}",
+                    "--no-input",
+                ],
+                capture_output=True,
+            )
+            if groupRevokeCmd.stderr:
+                print(f"complete! str({groupRevokeCmd.stderr})")
+
+        for user in allUsers:
+            print(
+                f"\t Revoking user {str(user['name'])} permissions for vault '{vault.name}'"
+            )
+            userRevokeCmd = subprocess.run(
+                [
+                    "op",
+                    "vault",
+                    "user",
+                    "revoke",
+                    f"--vault={vault.uuid}",
+                    f"--user={user['id']}",
+                    "--no-input",
+                ],
+                capture_output=True,
+            )
+            if userRevokeCmd.stderr:
+                print(f"ERROR! {str(userRevokeCmd.stderr)}")
 
 
 def main():
     vaults = []
     vaultGroups = {}
     vaultDetails = getVaults()
-    # vaultDetails = getVaultDetails(vaultList)
 
     for vault in vaultDetails:
         vaults.append(
@@ -112,15 +214,33 @@ def main():
             vaultGroups[vault.name] = []
         vaultGroups[vault.name].append(vault)
 
-    for groupName, vaults in vaultGroups.items():
-        identifyTrackedVault(groupName, vaults)
+    for vaultGroupName, vaults in vaultGroups.items():
+        if len(vaults) == 1:
+            print(
+                f"Vault with name {vaultGroupName} is unique. Skipping de-duplication."
+            )
+            continue
+        trackedVault, dataVault, otherVaults = identifyTrackedVault(
+            vaultGroupName, vaults
+        )
 
-    # Collect all vaults
-    # Identify identically named vaults
-    # For a set of duplicates, sort by number of items
-    # Move items from vault with most items to vault with zero
-    # prefix duplicates with `dup-` and if more than one, add numeric suffix
-    # remove all permissions from non-canonical vaults
+        print(
+            "\tTracked Vault: ",
+            trackedVault.name,
+            "ITEMS: ",
+            trackedVault.itemCount,
+            "\n\tData Vault: ",
+            dataVault.name,
+            "ITEMS: ",
+            dataVault.itemCount,
+            "\n\tOther vaults: ",
+            str(otherVaults),
+        )
+        moveItemsToTrackedVault(trackedVault, dataVault)
+        untrackedVaults = otherVaults
+        untrackedVaults.append(dataVault)
+        renameUntrackedVaults(untrackedVaults)
+        revokeUntrackedVaultPermissions(untrackedVaults)
 
 
 main()

--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -76,6 +76,23 @@ def identifyTrackedVault(vaultGroupName, vaults):
     return dataVault, trackedVault, otherVaults
 
 
+def grantOwnerPermissions(vaultID):
+    ownerPermissions = "view_items,create_items,edit_items,archive_items,delete_items,view_and_copy_passwords,view_item_history,import_items,export_items,copy_and_share_items,print_items,manage_vault"
+    subprocess.run(
+        [
+            "op",
+            "vault",
+            "group",
+            "grant",
+            f"--vault={vaultID}",
+            f"--group=Owners",
+            f"--permissions={ownerPermissions}",
+            "--no-input",
+        ],
+        capture_output=True,
+    )
+
+
 def getVaultItems(vaultID):
     try:
         return subprocess.run(
@@ -129,6 +146,7 @@ def renameUntrackedVaults(untrackedVaults):
 
 # revoke all access and permissions from untracked vaults
 def revokeUntrackedVaultPermissions(untrackedVaults):
+    permissions = "view_items,create_items,edit_items,archive_items,delete_items,view_and_copy_passwords,view_item_history,import_items,export_items,copy_and_share_items,print_items,manage_vault"
     for vault in untrackedVaults:
         print(f"Modifying permissions for vault '{vault.name}'.")
         allgroups = json.loads(
@@ -160,6 +178,7 @@ def revokeUntrackedVaultPermissions(untrackedVaults):
                     "revoke",
                     f"--vault={vault.uuid}",
                     f"--group={group['id']}",
+                    f"--permissions={permissions}",
                     "--no-input",
                 ],
                 capture_output=True,
@@ -220,6 +239,8 @@ def main():
                 f"Vault with name {vaultGroupName} is unique. Skipping de-duplication."
             )
             continue
+        for vault in vaults:
+            grantOwnerPermissions(vault.uuid)
         trackedVault, dataVault, otherVaults = identifyTrackedVault(
             vaultGroupName, vaults
         )

--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -23,11 +23,12 @@ class Vault:
 # Get a list of vaults the logged-in user has access to
 def getVaults():
     try:
-        return subprocess.run(
+        getVaultsCommand = subprocess.run(
             ["op", "vault", "list", "--group=Owners", "--format=json"],
             check=True,
             capture_output=True,
-        ).stdout
+        )
+        return getVaultsCommand.stdout
     except Exception as err:
         print(
             f"Encountered an error getting the list of vaults you have access to: ", err

--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+import csv
+import json
+from collections import defaultdict
+from datetime import datetime
+
+scriptPath = os.path.dirname(__file__)
+outputPath = scriptPath  # Optionally choose an alternative output path here.
+
+
+# Get a list of vaults the logged-in user has access to
+def getVaults():
+    try:
+        return subprocess.run(
+            "op vault list --group=Owners --format=json",
+            shell=True,
+            check=True,
+            capture_output=True,
+        ).stdout
+    except Exception as err:
+        print(
+            f"Encountered an error getting the list of vaults you have access to: ", err
+        )
+        return
+
+
+# Get the details of a vault
+def getVaultDetails(vaultID):
+    try:
+        return subprocess.run(
+            ["op", "vault", "get", f"{vaultID}", "--format=json"],
+            check=True,
+            capture_output=True,
+        ).stdout
+    except Exception as err:
+        print(f"Encountered an error getting details for vault {vaultID}: ", err)
+        return
+
+
+def main():
+    vaults = json.loads(getVaults())
+
+
+main()

--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -15,8 +15,7 @@ outputPath = scriptPath  # Optionally choose an alternative output path here.
 def getVaults():
     try:
         return subprocess.run(
-            "op vault list --group=Owners --format=json",
-            shell=True,
+            ["op", "vault", "list", "--group=Owners", "--format=json"],
             check=True,
             capture_output=True,
         ).stdout

--- a/migration/cleanup-scripts/move_items_to_tracked_vault.py
+++ b/migration/cleanup-scripts/move_items_to_tracked_vault.py
@@ -56,7 +56,7 @@ def getVaults():
 # From a list of vaults within a group of identically-named vaults
 def identifyTrackedVault(vaultGroupName, vaults):
     print(
-        "\tIdentifying tracked, data, and other duplicates for vault group: ",
+        "\tIdentifying tracked, data, and other duplicates for vault group:",
         vaultGroupName,
     )
 
@@ -252,7 +252,7 @@ def main():
                 f"Vault with name '{vaultGroupName}' is unique. Skipping de-duplication."
             )
             continue
-        print("Processing vault group: ", vaultGroupName)
+        print("Processing vault group:", vaultGroupName)
         print(
             f"\tGranting Owners group required permissions for vault named '{vaultGroupName}'"
         )

--- a/migration/cleanup-scripts/tests/create_dup_vaults.py
+++ b/migration/cleanup-scripts/tests/create_dup_vaults.py
@@ -1,8 +1,16 @@
 #!/usr/bin/python3
-
+import argparse
 import subprocess
 import random
 import json
+
+
+parser = argparse.ArgumentParser(
+    "Generate some number of vaults with random names. This will randomly generate some duplicates and triplicates. It will also generate a random number of Login items in one duplicate vault. Use the --delete flag to delete all non-Private vaults."
+)
+parser.add_argument("--delete", action="store_true", dest="delete")
+args = parser.parse_args()
+
 
 vaultNamelist = [
     "Radiant Blue Sky",
@@ -164,10 +172,13 @@ def createVault(vaultName, numOfDupes):
 
 
 def main():
-    for name in random.sample(vaultNamelist, 10):
-        numOfDupes = random.randrange(1, 4)
-        createVault(name, numOfDupes)
+    if args.delete:
+        deleteAllVaults()
+
+    else:
+        for name in random.sample(vaultNamelist, 10):
+            numOfDupes = random.randrange(1, 4)
+            createVault(name, numOfDupes)
 
 
 main()
-# deleteAllVaults()

--- a/migration/cleanup-scripts/tests/create_dup_vaults.py
+++ b/migration/cleanup-scripts/tests/create_dup_vaults.py
@@ -9,6 +9,8 @@ parser = argparse.ArgumentParser(
     "Generate some number of vaults with random names. This will randomly generate some duplicates and triplicates. It will also generate a random number of Login items in one duplicate vault. Use the --delete flag to delete all non-Private vaults."
 )
 parser.add_argument("--delete", action="store_true", dest="delete")
+parser.add_argument("--vaults", action="store", dest="numberOfVaults", default=10)
+parser.add_argument("--create-duplicates", action="store_true", dest="duplicates")
 args = parser.parse_args()
 
 
@@ -173,11 +175,17 @@ def createVault(vaultName, numOfDupes):
 
 def main():
     if args.delete:
+        print(f"Deleting all non-Private vaults in the account.")
         deleteAllVaults()
 
     else:
-        for name in random.sample(vaultNamelist, 10):
-            numOfDupes = random.randrange(1, 4)
+        print(f"Creating {args.numberOfVaults} vaults. Duplicates: {args.duplicates}")
+        for name in random.sample(vaultNamelist, int(args.numberOfVaults)):
+            if args.duplicates:
+                numOfDupes = random.randrange(1, 4)
+            else:
+                numOfDupes = 1
+            print(f"Creating vault: {name}. Will create {numOfDupes} of the same name.")
             createVault(name, numOfDupes)
 
 

--- a/migration/cleanup-scripts/tests/create_dup_vaults.py
+++ b/migration/cleanup-scripts/tests/create_dup_vaults.py
@@ -121,14 +121,36 @@ def createItems(vaultName):
             print(f"There was a problem creating an item: {err}")
 
 
+def setVaultPermissions(vaultID):
+    permissions = "view_items,edit_items,create_items,archive_items,delete_items,view_item_history,view_and_copy_passwords,import_items,copy_and_share_items,manage_vault"
+    print(f"setting permissions for vault {vaultID}")
+    permissionSet = subprocess.run(
+        [
+            "op",
+            "vault",
+            "group",
+            "grant",
+            f"--vault={vaultID}",
+            f"--group=f5pgjqtdfxz3qm2c3jw7w62v5q",
+            f"--permissions={permissions}",
+            "--no-input",
+        ],
+        capture_output=True,
+    )
+    print(permissionSet)
+
+
 def createVault(vaultName, numOfDupes):
     for i in range(numOfDupes):
         try:
-            subprocess.run(
+            createdVault = subprocess.run(
                 ["op", "vault", "create", vaultName], check=True, capture_output=True
             )
             if i == 0:
                 createItems(vaultName)
+            if i == 1:
+                vaultID = createdVault.stdout.split()[1].decode()
+                setVaultPermissions(vaultID)
         except Exception as err:
             print(f"There was a problem creating a vault: {err}")
 

--- a/migration/cleanup-scripts/tests/create_dup_vaults.py
+++ b/migration/cleanup-scripts/tests/create_dup_vaults.py
@@ -151,6 +151,14 @@ def createVault(vaultName, numOfDupes):
             if i == 1:
                 vaultID = createdVault.stdout.split()[1].decode()
                 setVaultPermissions(vaultID)
+            else:
+                vaultID = createdVault.stdout.split()[1].decode()
+                subprocess.run(
+                    f"op item create --title='thirdVault' username=testUser@example.com --vault='{vaultID}' --category=login --generate-password --url='example.com'",
+                    check=True,
+                    shell=True,
+                    capture_output=True,
+                )
         except Exception as err:
             print(f"There was a problem creating a vault: {err}")
 

--- a/migration/cleanup-scripts/tests/create_dup_vaults.py
+++ b/migration/cleanup-scripts/tests/create_dup_vaults.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python3
+
+import subprocess
+import random
+import json
+
+vaultNamelist = [
+    "Radiant Blue Sky",
+    "Mountain Adventure",
+    "Whimsical Sunflower",
+    "Sizzling Tacos-27",
+    "Sparkling River",
+    "Cosmic Dance Party",
+    "Quantum Leap",
+    "Midnight Whisper",
+    "4 Gleaming Stars",
+    "Mystic Moonlight",
+    "Enchanted Forest",
+    "Turbo-Charged Rocket",
+    "Oceanic Dreamscape",
+    "Electric Jungle",
+    "Velvet Dreams-10",
+    "Silver Lining",
+    "Wonderland Quest",
+    "Solar Eclipse",
+    "Lost Balloons-99",
+]
+
+itemNamelist = [
+    "Ethereal Horizon",
+    "Hypnotic Hydra",
+    "Harmony Of Numbers",
+    "Solarium Symphony",
+    "Emerald Dragons",
+    "Whirlwind Jubilee",
+    "Quantum Quasar",
+    "Lost Galaxies",
+    "Crimson Velvet",
+    "Sapphire Echo",
+    "Nebulaic Nectar",
+    "Techno Zenith",
+    "21 Whispering Pines",
+    "Quantum Leap Frog",
+    "Celestial Cacophony",
+    "Electric Embrace",
+    "Serendipity Vortex",
+    "Galactics Gazelle",
+    "Neon Nocturne",
+    "Tranquil Thunder",
+    "Pulsar Harmony",
+    "Jovian Winds",
+    "Echoing Cascade",
+    "Nebulaic Nebula",
+    "Crystal Lagoon",
+    "Lunar Lullaby",
+    "Quantum-Quokka",
+    "Midnight Monsoon",
+    "9-Emerald Enigmas",
+    "Electric Equinox",
+    "Mystical Mingle",
+    "Whispering 33-Willows",
+    "Lunar Labyrinth",
+    "Sapphire Siesta",
+    "Celestial Chaos",
+    "Hypnotic Harmony",
+    "Quantum Quest",
+    "Velvet Vigil",
+    "Enigma Ethereal",
+    "Crimson Comet",
+    "Radiant Rainforest",
+    "Techno Tempest",
+    "Solar-Symphony_123",
+    "Quantum Quartet",
+    "Ethereal Eclipse",
+    "Electric Eden",
+    "Nebulaic Nectarine",
+    "Cosmic Carousel",
+    "Hypnotic Horizon",
+    "Celestial Cerulean",
+    "Quantum Quasar Quartet",
+    "Serendipity Spectacle",
+    "23 Whirling Wonders",
+    "Crimson Cascades",
+    "Lunar Luminary",
+    "Mystic Melange",
+    "Electric Ethereal",
+    "Nebulaic Nymph",
+]
+
+
+def deleteAllVaults():
+    vaultList = json.loads(
+        subprocess.run(
+            ["op", "vault", "list", "--format=json"],
+            check=True,
+            capture_output=True,
+        ).stdout
+    )
+    for vault in vaultList:
+        id = vault["id"]
+        if "Private" not in vault["name"]:
+            subprocess.run(
+                ["op", "vault", "delete", id],
+                check=True,
+                capture_output=True,
+            ).stdout
+
+
+def createItems(vaultName):
+    for i in range(random.randint(5, 30)):
+        itemName = "".join((random.choice(itemNamelist)))
+        url = f"https://{vaultName}-{itemName.replace(' ', '')}"
+        try:
+            subprocess.run(
+                f"op item create --title='{itemName}' username=testUser@example.com --vault='{vaultName}' --category=login --generate-password --url='{url}.com'",
+                check=True,
+                shell=True,
+                capture_output=True,
+            )
+        except Exception as err:
+            print(f"There was a problem creating an item: {err}")
+
+
+def createVault(vaultName, numOfDupes):
+    for i in range(numOfDupes):
+        try:
+            subprocess.run(
+                ["op", "vault", "create", vaultName], check=True, capture_output=True
+            )
+            if i == 0:
+                createItems(vaultName)
+        except Exception as err:
+            print(f"There was a problem creating a vault: {err}")
+
+
+def main():
+    for name in random.sample(vaultNamelist, 10):
+        numOfDupes = random.randrange(1, 4)
+        createVault(name, numOfDupes)
+
+
+main()
+# deleteAllVaults()

--- a/migration/cleanup-scripts/tests/itemNamelist
+++ b/migration/cleanup-scripts/tests/itemNamelist
@@ -1,0 +1,58 @@
+Ethereal Horizon
+Hypnotic Hydra
+Harmony Of Numbers
+Solarium Symphony
+Emerald Dragons
+Whirlwind Jubilee
+Quantum Quasar
+Lost Galaxies
+Crimson Velvet
+Sapphire Echo
+Nebulaic Nectar
+Techno Zenith
+21 Whispering Pines
+Quantum Leap Frog
+Celestial Cacophony
+Electric Embrace
+Serendipity Vortex
+Galactic's Gazelle
+Neon Nocturne
+Tranquil Thunder
+Pulsar Harmony
+Jovian Winds
+Echoing Cascade
+Nebulaic Nebula
+Crystal Lagoon
+Lunar Lullaby
+Quantum-Quokka
+Midnight Monsoon
+9-Emerald Enigmas
+Electric Equinox
+Mystical Mingle
+Whispering 33-Willows
+Lunar Labyrinth
+Sapphire Siesta
+Celestial Chaos
+Hypnotic Harmony
+Quantum Quest
+Velvet Vigil
+Enigma Ethereal
+Crimson Comet
+Radiant Rainforest
+Techno Tempest
+Solar-Symphony_123
+Quantum Quartet
+Ethereal Eclipse
+Electric Eden
+Nebulaic Nectarine
+Cosmic Carousel
+Hypnotic Horizon
+Celestial Cerulean
+Quantum Quasar Quartet
+Serendipity Spectacle
+23 Whirling Wonders
+Crimson Cascades
+Lunar Luminary
+Mystic Melange
+Electric Ethereal
+Nebulaic Nymph

--- a/migration/cleanup-scripts/tests/vaultNamelist
+++ b/migration/cleanup-scripts/tests/vaultNamelist
@@ -1,0 +1,38 @@
+Radiant Blue Sky
+Mountain Adventure
+Whimsical Sunflower
+Sizzling Tacos-27
+Sparkling River
+Cosmic Dance Party
+Quantum Leap
+Midnight Whisper
+4 Gleaming Stars
+Mystic Moonlight
+Enchanted Forest
+Turbo-Charged Rocket
+Oceanic Dreamscape
+Electric Jungle
+Velvet Dreams-10
+Silver Lining
+Wonderland Quest
+Solar Eclipse
+Lost Balloons-99
+Tranquil Meadow
+Techno Harmony
+Celestial Cascades
+Thunderstorm Fury
+Whirling Dervishes
+Ivory Tiger Lily
+Nebula Rising
+Midnight Owl Serenade
+Infinite Paths-8
+Quantum Spiral
+Solar Flare Fiesta
+Echoing Canyon
+Velvet Vortex
+Enigma Whirlpool
+Mystic-42 Tomorrows
+Crystal Zephyr
+Galactic Harbor
+Pulsating Beats
+Wildfire Melody


### PR DESCRIPTION
In certain circumstances during a LastPass migration, duplicate vaults may be created. This can happen with the Import Metadata Vault is manually modified, or other actions are taken that prevent 1Password from accurately tracking the state of the 1Password account relative to the LastPass account. 

### Primary Addition
Sometimes the result is duplicates or triplicate vaults that _seem_ to have the following pattern:
* A 1Password vault that contains the migrated LastPass data and which the LastPass Import Metadata vault seems to no longer be aware of. This is the "Data Vault" and has the most items of all vaults in the set of duplicates. 
* A 1Password vault of the same name that has no data, but which the LastPass Import Metadata vault seems to be keeping track of. This is the "Tracked Vault" and has zero items. 
* There may be one or more other vaults with more than zero items, but fewer than the Data Vault

This script will:
* Identify vaults with identical names
* Grant the Owners group full permissions in order to facilitate the next steps. 
* Move all items from the "Data Vault" to the "Tracked Vault"
* Rename the Data Vault with a "dup-" prefix and a numeric suffix
* If there are more than two vaults of the same name, the other vaults are also renamed as above. Data in those vaults is unmodified. 
* Permissions for all groups and all users for all vaults that are not the Tracked vault are revoked. 

This allows for the effective "archiving" of untracked vaults, and should permit the organization to continue their import. 
* Tracked vaults will receive permissions updates when the Importer is re-run and now contain the correct data. 
* The non-tracked vaults can be easily reviewed and potentially subsequently deleted. 

### Secondary Addition
This PR also adds an environment-generating script. This script is intended to programatically recreate the environment the primary script included in this PR is remediating. 
* By default it creates 10 vaults with random names and a random number of items. 
* Use the --delete flag to delete all non-Private vaults in the account. 
* Use the --vaults flag to override the default 10 vaults with your desired number. 
* Use the --create-duplicates flag to optionally create between 2 and 3 duplicate vaults. 
  * A random number of items will be created in one of the vaults. In the case triplicates are being created, a single item will be created in the triplicate. 
* Some permissions are randomly assigned.
