### PR TITLE
add workflow to identify and manage stale issues and PRs

### DIFF
--- a/.github/workflows/stale-checker.yml
+++ b/.github/workflows/stale-checker.yml
@@ -21,8 +21,23 @@ jobs:
       - uses: actions/stale@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: "This issue has been quiet for a while. Nudging the assigned person."
-          stale-pr-message: "This PR has been quiet for a while. Nudging the assignee and reviewers."
+          days-before-stale: 14
           stale-issue-label: "stale:needs-attention"
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed in two weeks if no further activity occurs.
+            1Password employees have been nudged.
           stale-pr-label: "stale:needs-attention"
-          days-before-stale: 0
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had recent activity.
+            It will be closed in two weeks if no further activity occurs.
+            1Password employees have been nudged.
+          days-before-close: 14
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity.
+            Please re-open if this still requires attention.
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity.
+            Please re-open if it is still required.
+          exempt-issue-labels: "keep-alive"
+          exempt-pr-labels: "keep-alive"

--- a/.github/workflows/stale-checker.yml
+++ b/.github/workflows/stale-checker.yml
@@ -1,0 +1,28 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue has been quiet for a while. Nudging the assigned person."
+          stale-pr-message: "This PR has been quiet for a while. Nudging the assignee and reviewers."
+          stale-issue-label: "stale:needs-attention"
+          stale-pr-label: "stale:needs-attention"
+          days-before-stale: 0


### PR DESCRIPTION
This PR introduces a GitHub workflow to identify stale issues and PRs. 
* It considers any issue or PR as stale if there is no activity for 14 days. 
  * A tag "stale:needs-attention" is applied to issues or PRs and a comment is added. 
* It closes a stale issue or PR after 14 days. 

To prevent the workflow from tagging or closing an issue or PR, apply the `keep-alive` tag. 