### PR TITLE
Fix Vault Migration Issues with Archived Items and Tidy Up Logging

### DIFF
--- a/onepassword_sdks/demo-vault-migration-webapp/README.md
+++ b/onepassword_sdks/demo-vault-migration-webapp/README.md
@@ -60,7 +60,8 @@ If something goes wrong:
 
 ## Limitations
 
-- The SDK, similar to the CLI and vault data export, cannot access or report on the passkey field. To transfer passkeys between 1Password accounts, use the 1Password app on your desktop or mobile device.
-- The app uses a self-signed certificate for HTTPS, which works for local testing but needs a real certificate for production.
-- You can’t change the vault names — the script just adds "(Migrated)" to the name in the destination account.
-- The app has fixed limits for how many vaults (2) and items (1) it processes at a time, which might need tweaking for big migrations.
+- Neither the 1Password SDK, CLI, nor vault data export can access or report on passkey fields. To transfer passkeys between 1Password accounts, use the 1Password desktop or mobile app.
+- The SDK does not natively support retrieving archived items for vault migration.
+- The application uses a self-signed certificate for HTTPS, suitable for local testing but requiring a valid certificate for production deployment.
+- Vault names cannot be modified during migration; the script appends "(Migrated)" to the destination vault names.
+- The application has fixed concurrency limits (2 vaults and 1 item processed simultaneously), which may need adjustment for large-scale migrations.

--- a/onepassword_sdks/demo-vault-migration-webapp/docker-compose.yml
+++ b/onepassword_sdks/demo-vault-migration-webapp/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: demo-vault-migration-webapp:v1.0.1
+    image: demo-vault-migration-webapp:v1.0.2
     ports:
       - "3001:3001"
     environment:

--- a/onepassword_sdks/demo-vault-migration-webapp/package.json
+++ b/onepassword_sdks/demo-vault-migration-webapp/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "description": "Tool to assist with migrating vaults from 1Password account to another.",
   "dependencies": {
-    "@1password/sdk": "^0.2.1",
+    "@1password/sdk": "^0.3.0",
     "body-parser": "^2.2.0",
     "ejs": "^3.1.10",
     "express": "^4.21.2",


### PR DESCRIPTION
## Pull Request Description

Hey folks, this PR sorts out some pesky vault migration issues caused by archived items and makes our logs a bit clearer. Here's what I did:

- Handled Archived Items with the SDK: Tweaked getVaultItemCount to use the 1Password SDK for counting items. We now grab active items with client.items.list(vaultId) to keep migrations focused on those. For archived items, we use client.items.list(vaultId, { type: "ByState", content: { active: false, archived: true } }) to count them and log their presence (like [INFO] Vault <vaultId> (<vaultName>): Contains X archived items) in migrationLog and vaultLogs. This way, we know about archived items but don’t try to migrate them or show them in the UI.

- Clearer Log Messages: Spruced up the log messages in /migration/list-vaults and migrateVault to say “active items” when reporting item counts. This makes it obvious we’re only dealing with active items and not archived ones.