### PR TITLE
Update SSH setup tutorial to link to developer docs

### DIFF
--- a/dev-onboarding-guide/checker-script.md
+++ b/dev-onboarding-guide/checker-script.md
@@ -2,7 +2,7 @@
 
 **What it does:**
 
-This script is a small diagnostic tool designed to help you quickly verify if your local macOS environment is correctly configured to use 1Password as your SSH agent. It performs several checks:
+This script is a small diagnostic tool designed to help you quickly verify if your local Mac or Linux environment is correctly configured to use 1Password as your SSH agent. It performs several checks:
 
 1. **`SSH_AUTH_SOCK` variable:** Verifies that the `SSH_AUTH_SOCK` environment variable is set and appears to point to the 1Password agent.
 2. **Agent accessibility & key listing:** Attempts to connect to the SSH agent (via `ssh-add -L`) to list loaded SSH keys, looking for indicators that they are managed by 1Password.

--- a/dev-onboarding-guide/checker-script.md
+++ b/dev-onboarding-guide/checker-script.md
@@ -1,0 +1,16 @@
+### About the [SSH Setup Checker Script](ssh-checker.sh)
+
+**What it does:**
+
+This script is a small diagnostic tool designed to help you quickly verify if your local macOS environment is correctly configured to use 1Password as your SSH agent. It performs several checks:
+
+1. **`SSH_AUTH_SOCK` variable:** Verifies that the `SSH_AUTH_SOCK` environment variable is set and appears to point to the 1Password agent.
+2. **Agent accessibility & key listing:** Attempts to connect to the SSH agent (via `ssh-add -L`) to list loaded SSH keys, looking for indicators that they are managed by 1Password.
+3. **GitHub connection test (optional):** Offers to run a test SSH connection to `git@github.com`. This doesn't check your GitHub permissions but allows you to observe if 1Password prompts for authentication as expected.
+
+**Why you might want to use it:**
+
+- **Troubleshooting:** If you're having trouble connecting to SSH servers after [setting up 1Password for SSH](ssh-guide.md), this script can help pinpoint common configuration issues.
+- **Verification:** After following the setup guide, run this script to confirm everything is working as expected.
+- **Self-service check:** Quickly perform a self-service diagnostic before reaching out for support.
+- **Peace of mind:** Make sure your SSH operations are indeed being securely handled by 1Password.

--- a/dev-onboarding-guide/ssh-guide.md
+++ b/dev-onboarding-guide/ssh-guide.md
@@ -2,7 +2,7 @@
 
 This guide will help you get your team started using the [1Password SSH Agent](https://developer.1password.com/docs/ssh) to manage their SSH keys and sign Git commits. By using 1Password for SSH, your team benefits from:
 
-- **Enhanced security:** Private keys are encrypted in your 1Password vault and only loaded into the SSH agent when needed, often protected by biometrics or Windows Hello.
+- **Enhanced security:** Private keys are encrypted in your 1Password vault and only loaded into the SSH agent when needed, optionally protected by biometrics or Windows Hello.
 - **Streamlined authentication:** No more repeatedly typing passphrases for SSH operations.
 - **Automatic setup:** Automatically generate SSH keys and configure Git commit signing from the 1Password app.
 - **Centralized Management:** Manage all your SSH keys alongside your other passwords and sensitive information in 1Password.

--- a/dev-onboarding-guide/ssh-guide.md
+++ b/dev-onboarding-guide/ssh-guide.md
@@ -49,7 +49,7 @@ When you're ready to onboard your team to 1Password for SSH & Git, have your tea
 
 ### Step 4: Verify SSH Client Configuration
 
-If your team uses Mac devices, you can use the SSH Setup Checker script to verify their local environment is correctly configured.
+If your team uses Mac or Linux devices, you can use the SSH Setup Checker script to verify their local environment is correctly configured.
 
 After the 1Password SSH agent is set up, it should typically be used by the system's SSH client automatically. This happens because the `SSH_AUTH_SOCK` environment variable is set to point to the 1Password agent's socket file.
 

--- a/dev-onboarding-guide/ssh-guide.md
+++ b/dev-onboarding-guide/ssh-guide.md
@@ -15,11 +15,13 @@ To use 1Password for SSH & Git, your team members will need:
 - A [1Password subscription](https://start.1password.com/sign-up/plan)
 - The [1Password desktop application](https://1password.com/downloads/)
 - The [1Password browser extension](https://1password.com/downloads/browser-extension)
-- (Optional) [1Password CLI](https://developer.1password.com/docs/cli/get-started/), to use the SSH setup validation script.
+- [1Password CLI](https://developer.1password.com/docs/cli/get-started/) (optional, to use the SSH setup validation script)
 
 ## Step 1: Make sure developer tools are enabled for your team
 
-First, make sure your policies are set to allow 1Password to automatically create SSH configuration files. This enables your team to easily connect to hosts using SSH keys stored in 1Password.
+First, make sure your [team policies](https://support.1password.com/team-policies/) are set up for developer tools.
+
+First, turn on the policy to allow 1Password to automatically create SSH configuration files. This enables your team to easily connect to hosts using SSH keys stored in 1Password.
 
 1. Sign in to your account on 1Password.com
 2. Select **Policies** in the sidebar
@@ -30,19 +32,20 @@ Then, under Sidebar Navigation, make sure **Developer Tools** is toggled off. If
 
 ## Step 2: Review best practices
 
+You can help your team use SSH best practices by sharing the following principles wiht them:
 
-- **Descriptive Key Names:** Name your SSH keys in 1Password clearly, indicating the service/machine and owner (e.g., `GitLab - MyProject - MacBookPro`, `AWS Staging Server Access`).
-- **Key Separation (Recommended):** If feasible, consider using different SSH keys for different critical services or environments.
-- **Regular Review:** Periodically review the public keys registered on your connected services (GitHub, etc.) and remove any that are no longer needed.
-- **Avoid Exporting Private Keys:** Only export private keys from 1Password if absolutely necessary and for a specific, secure purpose.
-- **Use system auth** With the 1Password SSH agent correctly set up, when you use an `ssh` command (e.g., `git pull`, `ssh user@server`), 1Password should prompt you for biometric authentication (fingerprint, face) or your system password. This allows secure and quick authentication instead of typing key passphrases.
+- **Descriptive key names:** Name your SSH keys in 1Password clearly, indicating the service/machine and owner (e.g., `GitLab - MyProject - MacBookPro`, `AWS Staging Server Access`).
+- **Key separation (recommended):** If feasible, consider using different SSH keys for different critical services or environments.
+- **Regular review:** Periodically review the public keys registered on your connected services (GitHub, etc.) and remove any that are no longer needed.
+- **Avoid exporting private keys:** Only export private keys from 1Password if absolutely necessary and for a specific, secure purpose.
+- **Use system authentication:** Make sure your team members have [Touch ID](https://support.1password.com/touch-id-mac/), [Windows Hello](https://support.1password.com/windows-hello/), or [system authentication](https://support.1password.com/system-authentication-linux/) turned on in the 1Password app. With system authentication turned on, when you use an `ssh` command (e.g., `git pull`, `ssh user@server`), 1Password prompts you for biometric authentication (fingerprint, face) or your system password. This allows secure and quick authentication instead of typing key passphrases.
 
 ## Step 3: Help your team get started
 
 When you're ready to onboard your team to 1Password for SSH & Git, have your team members follow the steps in the following articles:
 
 1. [Get started with 1Password for SSH](https://developer.1password.com/docs/ssh/get-started)
-2. [Sign Git commits with SSH](https://developer.1password.com/docs/ssh/git-commit-signing)
+3. [Sign Git commits with SSH](https://developer.1password.com/docs/ssh/git-commit-signing)
 
 ### Step 4: Verify SSH Client Configuration
 
@@ -68,12 +71,10 @@ To verify that their SSH setup is correct after enabling the SSH agent or making
       IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
   ```
 
-  **Note:** The path for `IdentityAgent` can vary by operating system and 1Password version. Check the 1Password app's settings for the correct path if you need to specify it manually.
-
 ## Troubleshooting
 
 - **"Agent not running or not detected":**
-  - Ensure the SSH agent is enabled in the 1Password desktop app settings.
+  - Make sure the SSH agent is enabled in the 1Password desktop app settings.
   - Try restarting your terminal session.
   - Run `echo $SSH_AUTH_SOCK` to see if the expected path is displayed.
 - **"Still being prompted for the passphrase of an old key file":**
@@ -84,21 +85,3 @@ To verify that their SSH setup is correct after enabling the SSH agent or making
   - Confirm the 1Password SSH agent is serving the correct key (you can check with `ssh-add -L`; your 1Password key should be listed).
   - Check the SSH daemon logs on the server (e.g., `/var/log/auth.log` or `/var/log/secure`) for more detailed error messages.
 
----
-
-### About the [SSH Setup Checker Script](ssh-checker.sh)
-
-**What it does:**
-
-This script is a small diagnostic tool designed to help you quickly verify if your local environment is correctly configured to use 1Password as your SSH agent. It performs several checks:
-
-1. **`SSH_AUTH_SOCK` Variable:** Verifies that the `SSH_AUTH_SOCK` environment variable is set and appears to point to the 1Password agent.
-2. **Agent Accessibility & Key Listing:** Attempts to connect to the SSH agent (via `ssh-add -L`) to list loaded SSH keys, looking for indicators that they are managed by 1Password.
-3. **GitHub Connection Test (Optional):** Offers to run a test SSH connection to `git@github.com`. This doesn't check your GitHub permissions but allows you to observe if 1Password prompts for authentication (e.g., biometrics) as expected.
-
-**Why you might want to use it:**
-
-- **Troubleshooting:** If you're having trouble connecting to SSH servers after setting up 1Password for SSH, this script can help pinpoint common configuration issues.
-- **Verification:** After following the setup guide, run this script to confirm everything is working as expected.
-- **Self-Service Check:** Quickly perform a self-service diagnostic before reaching out for support.
-- **Peace of Mind:** Ensure your SSH operations are indeed being securely handled by 1Password.

--- a/dev-onboarding-guide/ssh-guide.md
+++ b/dev-onboarding-guide/ssh-guide.md
@@ -5,7 +5,7 @@ This guide will help you get your team started using the [1Password SSH Agent](h
 - **Enhanced security:** Private keys are encrypted in your 1Password vault and only loaded into the SSH agent when needed, optionally protected by biometrics or Windows Hello.
 - **Streamlined authentication:** No more repeatedly typing passphrases for SSH operations.
 - **Automatic setup:** Automatically generate SSH keys and configure Git commit signing from the 1Password app.
-- **Centralized Management:** Manage all your SSH keys alongside your other passwords and sensitive information in 1Password.
+- **Centralized management:** Manage all your SSH keys alongside your other passwords and sensitive information in 1Password.
 - **Consistency:** Establish a consistent and secure SSH key management practice across the team.
 
 ## Prerequisites
@@ -19,7 +19,7 @@ To use 1Password for SSH & Git, your team members will need:
 
 ## Step 1: Make sure developer tools are enabled for your team
 
-First, make sure your [team policies](https://support.1password.com/team-policies/) are set up for developer tools.
+Before you help your team get started with 1Password for SSH, make sure your [team policies](https://support.1password.com/team-policies/) are set up for developer tools.
 
 First, turn on the policy to allow 1Password to automatically create SSH configuration files. This enables your team to easily connect to hosts using SSH keys stored in 1Password.
 
@@ -32,7 +32,7 @@ Then, under Sidebar Navigation, make sure **Developer Tools** is toggled off. If
 
 ## Step 2: Review best practices
 
-You can help your team use SSH best practices by sharing the following principles wiht them:
+You can help your team use SSH in a secure and efficient manner by sharing the following best practices with them:
 
 - **Descriptive key names:** Name your SSH keys in 1Password clearly, indicating the service/machine and owner (e.g., `GitLab - MyProject - MacBookPro`, `AWS Staging Server Access`).
 - **Key separation (recommended):** If feasible, consider using different SSH keys for different critical services or environments.

--- a/dev-onboarding-guide/ssh-guide.md
+++ b/dev-onboarding-guide/ssh-guide.md
@@ -1,107 +1,76 @@
-# Team SSH Key Onboarding Guide (Using 1Password)
+# Administrators: Get started with 1Password for SSH & Git
 
-## 1. Introduction
+This guide will help you get your team started using the [1Password SSH Agent](https://developer.1password.com/docs/ssh) to manage their SSH keys and sign Git commits. By using 1Password for SSH, your team benefits from:
 
-This guide offers a suggested standard process for using 1Password to manage your team's SSH keys securely and efficiently. By using 1Password for your SSH keys, you benefit from:
-
-- **Enhanced Security:** Private keys are encrypted in your 1Password vault and only loaded into the SSH agent when needed, often protected by biometrics or Windows Hello.
-- **Improved Convenience:** No more repeatedly typing passphrases for SSH operations.
+- **Enhanced security:** Private keys are encrypted in your 1Password vault and only loaded into the SSH agent when needed, often protected by biometrics or Windows Hello.
+- **Streamlined authentication:** No more repeatedly typing passphrases for SSH operations.
+- **Automatic setup:** Automatically generate SSH keys and configure Git commit signing from the 1Password app.
 - **Centralized Management:** Manage all your SSH keys alongside your other passwords and sensitive information in 1Password.
-- **Easy Setup & Consistency:** Establishes a consistent and secure SSH key management practice across the team.
+- **Consistency:** Establish a consistent and secure SSH key management practice across the team.
 
-## 2. Prerequisites
+## Prerequisites
 
-- **1Password Account:** A 1Password Business, Teams, or individual account (if team members manage their own).
-- **1Password Desktop Application:** Installed on macOS, Windows, or Linux.
-  - [1Password Downloads Page](https://1password.com/downloads/)
-- **(Recommended) 1Password Browser Extension:** Installed.
-- **(Optional, for checker script & advanced use) 1Password CLI (`op`):** Installed.
-  - [Install the 1Password CLI](https://developer.1password.com/docs/cli/get-started/)
+To use 1Password for SSH & Git, your team members will need:
 
-## 3. Setup Instructions
+- A [1Password subscription](https://start.1password.com/sign-up/plan)
+- The [1Password desktop application](https://1password.com/downloads/)
+- The [1Password browser extension](https://1password.com/downloads/browser-extension)
+- (Optional) [1Password CLI](https://developer.1password.com/docs/cli/get-started/), to use the SSH setup validation script.
 
-### 3.1. Enable the 1Password SSH Agent
+## Step 1: Make sure developer tools are enabled for your team
 
-You need to enable the SSH agent in the 1Password desktop app.
+First, make sure your policies are set to allow 1Password to automatically create SSH configuration files. This enables your team to easily connect to hosts using SSH keys stored in 1Password.
 
-1. **Open the 1Password desktop application.**
-2. **Navigate to Preferences/Settings:**
-   - **macOS:** `1Password` menu > `Settings` (or `Preferences`) > `Developer` tab.
-   - **Windows:** `⋮` (menu button) > `Settings` > `Developer` tab.
-   - **Linux:** `Menu` > `Settings` (or `Ctrl+,`) > `Developer` tab.
-3. **Find the "SSH Agent" section.**
-4. **Check the box for "Use the SSH agent"** (or "Turn on SSH agent").
-5. **(Recommended)** Enable the option "Authorize SSH key use with biometrics or system password."
-6. **Set a default SSH key (optional):** If you have a key you use frequently, you can set it as the default.
-7. **Close the settings.** You might see on-screen instructions about how 1Password configures the SSH agent socket (`SSH_AUTH_SOCK`). Usually, restarting your terminal session will set this up automatically.
+1. Sign in to your account on 1Password.com
+2. Select **Policies** in the sidebar
+3. Select **Manage** under "Sharing and permissions".
+4. Under Developer Permissions, make sure "Allow automatic creation of SSH configuration file" is toggled on.
 
-### 3.2. Generate or Import SSH Keys
+Then, under Sidebar Navigation, make sure **Developer Tools** is toggled off. If the setting is toggled on, your team **will not** see the SSH agent in their app.
 
-#### Generate a New SSH Key in 1Password (Recommended)
+## Step 2: Review best practices
 
-1. In the 1Password desktop app, select the vault where you want to save the key.
-2. Click the "+ New Item" button and select "SSH Key."
-3. Choose "Generate a new private key."
-4. Select the key type (Ed25519 is recommended, or RSA) and bit length (4096 recommended for RSA).
-5. Give your key a clear title (e.g., `GitHub - [Your Name]`, `AWS Production - [Your Name]`).
-6. Click "Save." The public key will be visible within the item.
 
-#### Import an Existing SSH Key into 1Password
+- **Descriptive Key Names:** Name your SSH keys in 1Password clearly, indicating the service/machine and owner (e.g., `GitLab - MyProject - MacBookPro`, `AWS Staging Server Access`).
+- **Key Separation (Recommended):** If feasible, consider using different SSH keys for different critical services or environments.
+- **Regular Review:** Periodically review the public keys registered on your connected services (GitHub, etc.) and remove any that are no longer needed.
+- **Avoid Exporting Private Keys:** Only export private keys from 1Password if absolutely necessary and for a specific, secure purpose.
+- **Use system auth** With the 1Password SSH agent correctly set up, when you use an `ssh` command (e.g., `git pull`, `ssh user@server`), 1Password should prompt you for biometric authentication (fingerprint, face) or your system password. This allows secure and quick authentication instead of typing key passphrases.
 
-If you must continue using an existing key, you can import it.
+## Step 3: Help your team get started
 
-1. In the 1Password desktop app, click the "+ New Item" button and select "SSH Key."
-2. Choose "Import an existing key."
-3. Drag and drop your private key file (e.g., `id_rsa`) or select the file.
-4. Give your key a clear title.
-5. **Important:** After importing, **securely delete the original private key file** (e.g., `~/.ssh/id_rsa`) from your disk.
+When you're ready to onboard your team to 1Password for SSH & Git, have your team members follow the steps in the following articles:
 
-### 3.3. Add Your Public Key to Services
+1. [Get started with 1Password for SSH](https://developer.1password.com/docs/ssh/get-started)
+2. [Sign Git commits with SSH](https://developer.1password.com/docs/ssh/git-commit-signing)
 
-Once you've generated or imported an SSH key, you need to add its public key to the services you'll be connecting to (GitHub, GitLab, AWS, internal servers, etc.).
+### Step 4: Verify SSH Client Configuration
 
-1. Open the SSH key item in 1Password.
-2. Click the "Copy" icon next to the public key field to copy the public key.
-3. Navigate to the SSH key settings page on each service and paste the copied public key.
-   - **GitHub:** `Settings` > `SSH and GPG keys` > `New SSH key`
-   - **GitLab:** `Preferences` > `SSH Keys`
-   - For servers, add it to the `~/.ssh/authorized_keys` file on the server.
+If your team uses Mac devices, you can use the SSH Setup Checker script to verify their local environment is correctly configured.
 
-### 3.4. Verify SSH Client Configuration
+After the 1Password SSH agent is set up, it should typically be used by the system's SSH client automatically. This happens because the `SSH_AUTH_SOCK` environment variable is set to point to the 1Password agent's socket file.
 
-Once the 1Password SSH agent is enabled, it should typically be used by your system's SSH client automatically. This happens because the `SSH_AUTH_SOCK` environment variable is set to point to the 1Password agent's socket file.
+To verify that their SSH setup is correct after enabling the SSH agent or making changes to shell configuration files, your team members can:
 
-- **Restart Your Terminal Session:** After enabling the SSH agent or making changes to shell configuration files like `~/.zshrc`, `~/.bashrc`, or `~/.config/fish/config.fish`, restart your terminal session or open a new tab/window.
-- **Verification:** You can check if `SSH_AUTH_SOCK` points to a 1Password-related path by running the following in your terminal:
+1. Open a terminal session, or restart an existing terminal session in a new tab or window.
+2. Check if `SSH_AUTH_SOCK` points to a 1Password-related path by running the following command:
 
   ```bash
   echo $SSH_AUTH_SOCK
   ```
 
-  The output should contain "1Password" (e.g., `/Users/youruser/Library/Group Containers/XXXXXXXXXX.com.1password/t/agent.sock`).
+  The output should contain "1Password" (for example, `/Users/youruser/Library/Group Containers/XXXXXXXXXX.com.1password/t/agent.sock`).
 
-- **`~/.ssh/config` file (If Needed):**
-  While usually not required, if you need specific configurations or have conflicts with other SSH agents, you can explicitly point to the 1Password agent in your `~/.ssh/config` file (adjust the path to your actual `SSH_AUTH_SOCK` value):
+- If you need specific configurations or have conflicts with other SSH agents, you can explicitly point to the 1Password agent in your `~/.ssh/config` file by adjusting the path to your actual `SSH_AUTH_SOCK` value:
 
   ```bash
   Host *
       IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
   ```
 
-  **Note:** The path for `IdentityAgent` can vary by OS and 1Password version. Check the 1Password app's settings for the correct path if you need to specify it manually.
+  **Note:** The path for `IdentityAgent` can vary by operating system and 1Password version. Check the 1Password app's settings for the correct path if you need to specify it manually.
 
-## 4. Using Biometrics or System Password
-
-With the 1Password SSH agent correctly set up, when you use an `ssh` command (e.g., `git pull`, `ssh user@server`), 1Password should prompt you for biometric authentication (fingerprint, face) or your system password. This allows secure and quick authentication instead of typing key passphrases.
-
-## 5. Best Practices
-
-- **Descriptive Key Names:** Name your SSH keys in 1Password clearly, indicating the service/machine and owner (e.g., `GitLab - MyProject - MacBookPro`, `AWS Staging Server Access`).
-- **Key Separation (Recommended):** If feasible, consider using different SSH keys for different critical services or environments.
-- **Regular Review:** Periodically review the public keys registered on your connected services (GitHub, etc.) and remove any that are no longer needed.
-- **Avoid Exporting Private Keys:** Only export private keys from 1Password if absolutely necessary and for a specific, secure purpose.
-
-## 6. Troubleshooting
+## Troubleshooting
 
 - **"Agent not running or not detected":**
   - Ensure the SSH agent is enabled in the 1Password desktop app settings.


### PR DESCRIPTION
This PR updates the SSH checker tool documentation to:
- Point to setup docs on developer.1password.com
- Separate checker tool documentation from SSH setup documentation
- Rewrite the setup information to be for an admin audience throughout
- Include information about SSH-related team policies
- Specify that the checker script will only work on Mac
- Remove mentions of non-existent settings and accurately describe how to accomplish these goals in the app
- Use 1Password style throughout